### PR TITLE
inject repository using hilt

### DIFF
--- a/app/src/androidTest/java/com/github/swent/echo/di/DependencyInjectionTest.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/di/DependencyInjectionTest.kt
@@ -1,6 +1,8 @@
 package com.github.swent.echo.di
 
 import com.github.swent.echo.authentication.AuthenticationService
+import com.github.swent.echo.data.repository.Repository
+import com.github.swent.echo.data.repository.RepositoryImpl
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.github.jan.supabase.SupabaseClient
@@ -29,6 +31,8 @@ class DependencyInjectionTest {
 
     @Inject lateinit var authenticationService: AuthenticationService
 
+    @Inject lateinit var repository: Repository
+
     @Before
     fun setUp() {
         // This tells Hilt to inject the [supabaseClient] and [authenticationService] fields.
@@ -47,5 +51,10 @@ class DependencyInjectionTest {
     @Test
     fun testAuthenticationServiceInjection() {
         assertEquals(SimpleAuthenticationService::class.java, authenticationService::class.java)
+    }
+
+    @Test
+    fun testRepositoryInjection() {
+        assertEquals(RepositoryImpl::class.java, repository::class.java)
     }
 }

--- a/app/src/main/java/com/github/swent/echo/di/RepositoryModule.kt
+++ b/app/src/main/java/com/github/swent/echo/di/RepositoryModule.kt
@@ -1,0 +1,24 @@
+package com.github.swent.echo.di
+
+import android.app.Application
+import com.github.swent.echo.data.repository.Repository
+import com.github.swent.echo.data.repository.RepositoryImpl
+import com.github.swent.echo.data.repository.datasources.RemoteDataSource
+import com.github.swent.echo.data.repository.datasources.Supabase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import io.github.jan.supabase.SupabaseClient
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RepositoryModule {
+
+    @Provides
+    fun provideRepository(application: Application, supabaseClient: SupabaseClient): Repository {
+        val remoteDataSource: RemoteDataSource = Supabase(supabaseClient)
+
+        return RepositoryImpl(remoteDataSource)
+    }
+}


### PR DESCRIPTION
based on #32 
~requires #32  to be merged first~ done

this allows to use use the main repository implementation without passing it manually
