### PR TITLE
Redesign the way MapViews are created to add support for MapLibre.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,6 +98,9 @@ dependencies {
     // Open Street Map
     implementation(libs.osmdroid.android)
 
+    // Map Libre
+    implementation(libs.android.sdk)
+    
     // Hilt
     implementation(libs.hilt.android)
     implementation(libs.androidx.hilt.navigation.compose)

--- a/app/src/androidTest/java/com/github/swent/echo/compose/map/MapViewAndroidTest.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/compose/map/MapViewAndroidTest.kt
@@ -2,6 +2,7 @@ package com.github.swent.echo.compose.map
 
 import android.view.View
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -36,7 +37,7 @@ class MapViewAndroidTest {
                     organizerId = "a",
                     title = "Bowling Event",
                     description = "",
-                    location = Location("Location 1", OsmdroidMapViewProvider.LAUSANNE_GEO_POINT),
+                    location = Location("Location 1", MAP_CENTER.toGeoPoint()),
                     startDate = Date.from(Instant.now()),
                     endDate = Date.from(Instant.now()),
                     tags = emptySet(),
@@ -49,10 +50,7 @@ class MapViewAndroidTest {
                     location =
                         Location(
                             "Location 2",
-                            OsmdroidMapViewProvider.LAUSANNE_GEO_POINT.destinationPoint(
-                                1000.0,
-                                90.0
-                            )
+                            MAP_CENTER.toGeoPoint().destinationPoint(1000.0, 90.0)
                         ),
                     startDate = Date.from(Instant.now()),
                     endDate = Date.from(Instant.now()),
@@ -67,17 +65,17 @@ class MapViewAndroidTest {
 
         @Composable
         private fun DummyMapDrawer() {
-            val e = remember { mutableStateOf(events) }
-            MapDrawer(context = context, events = e)
+            val e by remember { mutableStateOf(events) }
+            MapDrawer(events = e)
         }
 
         @Composable
         private fun <T : View> DummyMapDrawer(p: IMapViewProvider<T>) {
-            val e = remember { mutableStateOf(events) }
+            val e by remember { mutableStateOf(events) }
             EchoAndroidView(factory = p::factory, update = p::update, events = e)
         }
 
-        private fun provider() = OsmdroidMapViewProvider(context)
+        private fun provider() = OsmdroidMapViewProvider()
     }
 
     @get:Rule val composeTestRule = createComposeRule()
@@ -101,14 +99,14 @@ class MapViewAndroidTest {
     fun mapViewCreatorShouldCreateViewWithCorrectZoom() {
         val p = provider()
         composeTestRule.setContent { DummyMapDrawer(p) }
-        assertEquals(p.getZoom(), OsmdroidMapViewProvider.ZOOM_DEFAULT, 0.0)
+        assertEquals(p.getZoom(), DEFAULT_ZOOM, 0.0)
     }
 
     @Test
     fun mapViewCreatorShouldCreateViewWithCorrectCenter() {
         val p = provider()
         composeTestRule.setContent { DummyMapDrawer(p) }
-        assertTrue(closeEnough(OsmdroidMapViewProvider.LAUSANNE_GEO_POINT, p.getCenter()))
+        assertTrue(closeEnough(MAP_CENTER.toGeoPoint(), p.getCenter()))
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/swent/echo/compose/map/MapViewAndroidTest.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/compose/map/MapViewAndroidTest.kt
@@ -1,7 +1,5 @@
 package com.github.swent.echo.compose.map
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -11,6 +9,8 @@ import com.github.swent.echo.data.model.Event
 import com.github.swent.echo.data.model.Location
 import java.time.Instant
 import java.util.Date
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -69,8 +69,10 @@ class MapViewAndroidTest {
     fun osmdroidConfigurationShouldHaveTheCorrectValues() {
         val p = provider()
         composeTestRule.setContent { MapDrawer(provider = p) }
-        assert(Configuration.getInstance().osmdroidBasePath == context.cacheDir)
-        assert(Configuration.getInstance().userAgentValue == context.packageName)
+        Configuration.getInstance().apply {
+            assertEquals(osmdroidBasePath, context.cacheDir)
+            assertEquals(userAgentValue, context.packageName)
+        }
     }
 
     @Test
@@ -84,20 +86,20 @@ class MapViewAndroidTest {
     fun mapViewCreatorShouldCreateViewWithCorrectZoom() {
         val p = provider()
         composeTestRule.setContent { MapDrawer(provider = p) }
-        assert(p.getZoom() == OsmdroidMapViewProvider.ZOOM_DEFAULT)
+        assertEquals(p.getZoom(), OsmdroidMapViewProvider.ZOOM_DEFAULT, 0.0)
     }
 
     @Test
     fun mapViewCreatorShouldCreateViewWithCorrectCenter() {
         val p = provider()
         composeTestRule.setContent { MapDrawer(provider = p) }
-        assert(closeEnough(OsmdroidMapViewProvider.LAUSANNE_GEO_POINT, p.getCenter()))
+        assertTrue(closeEnough(OsmdroidMapViewProvider.LAUSANNE_GEO_POINT, p.getCenter()))
     }
 
     @Test
     fun mapViewCreatorShouldCreateViewWithCorrectOutlineClip() {
         val p = provider()
         composeTestRule.setContent { MapDrawer(provider = p) }
-        assert(p.getClipToOutline())
+        assertTrue(p.getClipToOutline())
     }
 }

--- a/app/src/androidTest/java/com/github/swent/echo/compose/map/MapViewAndroidTest.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/compose/map/MapViewAndroidTest.kt
@@ -7,6 +7,10 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.github.swent.echo.data.model.Event
+import com.github.swent.echo.data.model.Location
+import java.time.Instant
+import java.util.Date
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,16 +24,50 @@ class MapViewAndroidTest {
     companion object {
         private const val ERROR_MARGIN_IN_METERS = 5.0
 
+        private val events =
+            listOf(
+                Event(
+                    eventId = "a",
+                    organizerId = "a",
+                    title = "Bowling Event",
+                    description = "",
+                    location = Location("Location 1", OsmdroidMapViewProvider.LAUSANNE_GEO_POINT),
+                    startDate = Date.from(Instant.now()),
+                    endDate = Date.from(Instant.now()),
+                    tags = emptySet(),
+                ),
+                Event(
+                    eventId = "b",
+                    organizerId = "a",
+                    title = "Swimming Event",
+                    description = "",
+                    location =
+                        Location(
+                            "Location 2",
+                            OsmdroidMapViewProvider.LAUSANNE_GEO_POINT.destinationPoint(
+                                1000.0,
+                                90.0
+                            )
+                        ),
+                    startDate = Date.from(Instant.now()),
+                    endDate = Date.from(Instant.now()),
+                    tags = emptySet(),
+                )
+            )
+
+        private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
         fun closeEnough(p1: GeoPoint, p2: IGeoPoint) =
             p1.distanceToAsDouble(p2) < ERROR_MARGIN_IN_METERS
+
+        fun provider(): OsmdroidMapViewProvider = OsmdroidMapViewProvider(context, events)
     }
 
     @get:Rule val composeTestRule = createComposeRule()
-    private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
     @Test
     fun osmdroidConfigurationShouldHaveTheCorrectValues() {
-        val p = OsmdroidMapViewProvider(context)
+        val p = provider()
         composeTestRule.setContent { MapDrawer(provider = p) }
         assert(Configuration.getInstance().osmdroidBasePath == context.cacheDir)
         assert(Configuration.getInstance().userAgentValue == context.packageName)
@@ -37,28 +75,28 @@ class MapViewAndroidTest {
 
     @Test
     fun mapDrawerShouldDisplayAndroidView() {
-        val p = OsmdroidMapViewProvider(context)
+        val p = provider()
         composeTestRule.setContent { MapDrawer(provider = p) }
         composeTestRule.onNodeWithTag("mapViewWrapper").assertIsDisplayed()
     }
 
     @Test
     fun mapViewCreatorShouldCreateViewWithCorrectZoom() {
-        val p = OsmdroidMapViewProvider(context)
+        val p = provider()
         composeTestRule.setContent { MapDrawer(provider = p) }
         assert(p.getZoom() == OsmdroidMapViewProvider.ZOOM_DEFAULT)
     }
 
     @Test
     fun mapViewCreatorShouldCreateViewWithCorrectCenter() {
-        val p = OsmdroidMapViewProvider(context)
+        val p = provider()
         composeTestRule.setContent { MapDrawer(provider = p) }
         assert(closeEnough(OsmdroidMapViewProvider.LAUSANNE_GEO_POINT, p.getCenter()))
     }
 
     @Test
     fun mapViewCreatorShouldCreateViewWithCorrectOutlineClip() {
-        val p = OsmdroidMapViewProvider(context)
+        val p = provider()
         composeTestRule.setContent { MapDrawer(provider = p) }
         assert(p.getClipToOutline())
     }

--- a/app/src/androidTest/java/com/github/swent/echo/compose/map/MapViewAndroidTest.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/compose/map/MapViewAndroidTest.kt
@@ -72,10 +72,12 @@ class MapViewAndroidTest {
         @Composable
         private fun <T : View> DummyMapDrawer(p: IMapViewProvider<T>) {
             val e by remember { mutableStateOf(events) }
-            EchoAndroidView(factory = p::factory, update = p::update, events = e)
+            EchoAndroidView(
+                factory = p::factory,
+                update = p::update,
+                events = e,
+            )
         }
-
-        private fun provider() = OsmdroidMapViewProvider()
     }
 
     @get:Rule val composeTestRule = createComposeRule()
@@ -96,23 +98,30 @@ class MapViewAndroidTest {
     }
 
     @Test
-    fun mapViewCreatorShouldCreateViewWithCorrectZoom() {
-        val p = provider()
+    fun mapViewProviderShouldCreateViewWithCorrectZoom() {
+        val p = OsmdroidMapViewProvider()
         composeTestRule.setContent { DummyMapDrawer(p) }
         assertEquals(p.getZoom(), DEFAULT_ZOOM, 0.0)
     }
 
     @Test
-    fun mapViewCreatorShouldCreateViewWithCorrectCenter() {
-        val p = provider()
+    fun mapViewProviderShouldCreateViewWithCorrectCenter() {
+        val p = OsmdroidMapViewProvider()
         composeTestRule.setContent { DummyMapDrawer(p) }
         assertTrue(closeEnough(MAP_CENTER.toGeoPoint(), p.getCenter()))
     }
 
     @Test
-    fun mapViewCreatorShouldCreateViewWithCorrectOutlineClip() {
-        val p = provider()
+    fun mapViewProviderShouldCreateViewWithCorrectOutlineClip() {
+        val p = OsmdroidMapViewProvider()
         composeTestRule.setContent { DummyMapDrawer(p) }
         assertTrue(p.getClipToOutline())
+    }
+
+    @Test
+    fun mapLibreMapViewProviderShouldDisplayView() {
+        val p = MapLibreMapViewProvider()
+        composeTestRule.setContent { DummyMapDrawer(p) }
+        composeTestRule.onNodeWithTag("mapViewWrapper").assertIsDisplayed()
     }
 }

--- a/app/src/androidTest/java/com/github/swent/echo/compose/map/MapViewAndroidTest.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/compose/map/MapViewAndroidTest.kt
@@ -1,5 +1,6 @@
 package com.github.swent.echo.compose.map
 
+import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
@@ -29,66 +30,53 @@ class MapViewAndroidTest {
     }
 
     @get:Rule val composeTestRule = createComposeRule()
-    private val tileSource: ITileSource = TileSourceFactory.MAPNIK
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
-
-    @Before
-    fun setUp() {
-        configureOsmdroid(context)
-    }
 
     @Test
     fun osmdroidConfigurationShouldHaveTheCorrectValues() {
-
+        val p = OsmdroidMapViewProvider(context)
+        composeTestRule.setContent { MapDrawer(provider = p) }
         assert(Configuration.getInstance().osmdroidBasePath == context.cacheDir)
         assert(Configuration.getInstance().userAgentValue == context.packageName)
     }
 
     @Test
     fun mapDrawerShouldDisplayAndroidView() {
-        composeTestRule.setContent { MapDrawer() }
+        val p = OsmdroidMapViewProvider(context)
+        composeTestRule.setContent { MapDrawer(provider = p) }
         composeTestRule.onNodeWithTag("mapViewWrapper").assertIsDisplayed()
     }
 
     @Test
     fun mapViewCreatorShouldCreateViewWithCorrectZoom() {
-        lateinit var mapView: MapView
+        val p = OsmdroidMapViewProvider(context)
         composeTestRule.setContent {
             MapDrawer(
-                mapViewFactory = {
-                    mapView = createMapView(it, tileSource)
-                    mapView
-                }
+                provider = p
             )
         }
-        assert(mapView.zoomLevelDouble == ZOOM_DEFAULT)
+        assert(p.getZoom() == OsmdroidMapViewProvider.ZOOM_DEFAULT)
     }
 
     @Test
     fun mapViewCreatorShouldCreateViewWithCorrectCenter() {
-        lateinit var mapView: MapView
+        val p = OsmdroidMapViewProvider(context)
         composeTestRule.setContent {
             MapDrawer(
-                mapViewFactory = {
-                    mapView = createMapView(it, tileSource)
-                    mapView
-                }
+                provider = p
             )
         }
-        assert(closeEnough(LAUSANNE_GEO_POINT, mapView.mapCenter))
+        assert(closeEnough(OsmdroidMapViewProvider.LAUSANNE_GEO_POINT, p.getCenter()))
     }
 
     @Test
     fun mapViewCreatorShouldCreateViewWithCorrectOutlineClip() {
-        lateinit var mapView: MapView
+        val p = OsmdroidMapViewProvider(context)
         composeTestRule.setContent {
             MapDrawer(
-                mapViewFactory = {
-                    mapView = createMapView(it, tileSource)
-                    mapView
-                }
+                provider = p
             )
         }
-        assert(mapView.clipToOutline)
+        assert(p.getClipToOutline())
     }
 }

--- a/app/src/androidTest/java/com/github/swent/echo/compose/map/MapViewAndroidTest.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/compose/map/MapViewAndroidTest.kt
@@ -1,6 +1,5 @@
 package com.github.swent.echo.compose.map
 
-import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
@@ -8,16 +7,12 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.osmdroid.api.IGeoPoint
 import org.osmdroid.config.Configuration
-import org.osmdroid.tileprovider.tilesource.ITileSource
-import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.GeoPoint
-import org.osmdroid.views.MapView
 
 @RunWith(AndroidJUnit4::class)
 class MapViewAndroidTest {
@@ -50,33 +45,21 @@ class MapViewAndroidTest {
     @Test
     fun mapViewCreatorShouldCreateViewWithCorrectZoom() {
         val p = OsmdroidMapViewProvider(context)
-        composeTestRule.setContent {
-            MapDrawer(
-                provider = p
-            )
-        }
+        composeTestRule.setContent { MapDrawer(provider = p) }
         assert(p.getZoom() == OsmdroidMapViewProvider.ZOOM_DEFAULT)
     }
 
     @Test
     fun mapViewCreatorShouldCreateViewWithCorrectCenter() {
         val p = OsmdroidMapViewProvider(context)
-        composeTestRule.setContent {
-            MapDrawer(
-                provider = p
-            )
-        }
+        composeTestRule.setContent { MapDrawer(provider = p) }
         assert(closeEnough(OsmdroidMapViewProvider.LAUSANNE_GEO_POINT, p.getCenter()))
     }
 
     @Test
     fun mapViewCreatorShouldCreateViewWithCorrectOutlineClip() {
         val p = OsmdroidMapViewProvider(context)
-        composeTestRule.setContent {
-            MapDrawer(
-                provider = p
-            )
-        }
+        composeTestRule.setContent { MapDrawer(provider = p) }
         assert(p.getClipToOutline())
     }
 }

--- a/app/src/main/java/com/github/swent/echo/MainActivity.kt
+++ b/app/src/main/java/com/github/swent/echo/MainActivity.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import com.github.swent.echo.compose.map.configureOsmdroid
 import com.github.swent.echo.compose.navigation.AppNavigationHost
 import com.github.swent.echo.ui.theme.EchoTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -16,7 +15,6 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        configureOsmdroid(this)
         setContent {
             EchoTheme {
                 // A surface container using the 'background' color from the theme

--- a/app/src/main/java/com/github/swent/echo/compose/map/IMapViewProvider.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/IMapViewProvider.kt
@@ -2,9 +2,18 @@ package com.github.swent.echo.compose.map
 
 import android.content.Context
 import android.view.View
+import com.github.swent.echo.data.model.Event
 
+/**
+ * A MapView provider is meant to be used by an
+ * [EchoAndroidView][com.github.swent.echo.compose.map.EchoAndroidView]. The methods `factory` and
+ * `update` directly correspond to the parameters of the same name in an
+ * [EchoAndroidView][com.github.swent.echo.compose.map.EchoAndroidView].
+ *
+ * @author alejandrocalles
+ */
 interface IMapViewProvider<T : View> {
     fun factory(context: Context): T
 
-    fun update(view: T)
+    fun update(view: T, events: List<Event>, callback: (Event) -> Unit)
 }

--- a/app/src/main/java/com/github/swent/echo/compose/map/IMapViewProvider.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/IMapViewProvider.kt
@@ -2,10 +2,9 @@ package com.github.swent.echo.compose.map
 
 import android.content.Context
 import android.view.View
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 
-interface IMapViewProvider <T: View> {
+interface IMapViewProvider<T : View> {
     fun factory(context: Context): T
+
     fun update(view: T)
 }

--- a/app/src/main/java/com/github/swent/echo/compose/map/IMapViewProvider.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/IMapViewProvider.kt
@@ -1,0 +1,11 @@
+package com.github.swent.echo.compose.map
+
+import android.content.Context
+import android.view.View
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+interface IMapViewProvider <T: View> {
+    fun factory(context: Context): T
+    fun update(view: T)
+}

--- a/app/src/main/java/com/github/swent/echo/compose/map/Map.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/Map.kt
@@ -1,28 +1,62 @@
 package com.github.swent.echo.compose.map
 
+import android.content.Context
 import android.view.View
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.viewinterop.AndroidView
-import org.osmdroid.util.GeoPoint
-import org.osmdroid.views.MapView
-
-fun updateMapView(view: MapView, newCenter: GeoPoint) {
-    view.apply { controller.setCenter(newCenter) }
-}
+import com.github.swent.echo.data.model.Event
 
 @Composable
-fun <T : View> MapDrawer(
+fun <T : View> EchoAndroidView(
     modifier: Modifier = Modifier,
-    provider: IMapViewProvider<T>,
+    factory: (Context) -> T,
+    update: (T, List<Event>, (Event) -> Unit) -> Unit,
+    events: MutableState<List<Event>>,
+    callback: (Event) -> Unit = {}
 ) {
     AndroidView(
+        modifier = modifier,
+        factory = factory,
+        update = { update(it, events.value, callback) }
+    )
+}
+
+/**
+ * This composable will draw a map that displays events.
+ *
+ * @param context Needed to initialize the [MapViewProvider][IMapViewProvider]. Can be the activity
+ *   itself if this function is called from an activity, or the `current` field of a
+ *   [LocalContext][androidx.compose.ui.platform.LocalContext] if it is called from another
+ *   composable.
+ * @param events The list of events to be displayed by the map. Whenever this list changes, the
+ *   event markers in the map will be automatically updated to match the list. Note that this
+ *   parameter is a [MutableState] containing a `List`, so the correct way to instantiate it is the
+ *   following: `val myEvents = remember { mutableStateOf(emptyList<Event>()) }`. Do NOT use the
+ *   `by` keyword. You can then pass it as an argument to this composable. If you want to change the
+ *   value stored in the [MutableState] to trigger a redraw of the markers, you can write
+ *   `myEvents.value = newEventList`.
+ * @param callback The function to be called when a marker on the map is clicked on. The [Event]
+ *   corresponding to the marker will be passed as an argument to this function.
+ */
+@Composable
+fun MapDrawer(
+    modifier: Modifier = Modifier,
+    context: Context,
+    events: MutableState<List<Event>>,
+    callback: (Event) -> Unit = {}
+) {
+    val provider = OsmdroidMapViewProvider(context)
+    EchoAndroidView(
         modifier = modifier.testTag("mapViewWrapper"),
-        factory = { provider.factory(it) },
+        factory = provider::factory,
         // Function that will be called when the view has been
         // inflated or state read in this function has been updated
         // AndroidView will recompose whenever said state changes
-        update = { provider.update(it) }
+        update = provider::update,
+        events = events,
+        callback = callback
     )
 }

--- a/app/src/main/java/com/github/swent/echo/compose/map/Map.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/Map.kt
@@ -2,19 +2,13 @@ package com.github.swent.echo.compose.map
 
 // osmdroid libraries
 
-import android.content.Context
 import android.view.View
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
-import org.osmdroid.config.Configuration
-import org.osmdroid.tileprovider.MapTileProviderBasic
-import org.osmdroid.tileprovider.tilesource.ITileSource
-import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
 
@@ -23,10 +17,7 @@ fun updateMapView(view: MapView, newCenter: GeoPoint) {
 }
 
 @Composable
-fun <T: View> MapDrawer(
-    modifier: Modifier = Modifier,
-    provider: IMapViewProvider<T>
-) {
+fun <T : View> MapDrawer(modifier: Modifier = Modifier, provider: IMapViewProvider<T>) {
     // var trigger by remember { mutableStateOf(...) }
     AndroidView(
         modifier = modifier.testTag("mapViewWrapper"),

--- a/app/src/main/java/com/github/swent/echo/compose/map/Map.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/Map.kt
@@ -3,6 +3,7 @@ package com.github.swent.echo.compose.map
 // osmdroid libraries
 
 import android.content.Context
+import android.view.View
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
@@ -17,43 +18,22 @@ import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
 
-val LAUSANNE_GEO_POINT: GeoPoint = GeoPoint(46.5197, 6.6323)
-const val ZOOM_DEFAULT = 15.0
-
-fun configureOsmdroid(context: Context) {
-    Configuration.getInstance().apply {
-        userAgentValue = context.packageName
-        osmdroidBasePath = context.cacheDir
-    }
-}
-
-fun createMapView(context: Context, tileSource: ITileSource): MapView =
-    MapView(context, MapTileProviderBasic(context)).apply {
-        setTileSource(tileSource)
-        // setOnClickListener { ... }
-        controller.setZoom(ZOOM_DEFAULT)
-        controller.setCenter(LAUSANNE_GEO_POINT)
-        clipToOutline = true
-    }
-
 fun updateMapView(view: MapView, newCenter: GeoPoint) {
     view.apply { controller.setCenter(newCenter) }
 }
 
-@Preview
 @Composable
-fun MapDrawer(
+fun <T: View> MapDrawer(
     modifier: Modifier = Modifier,
-    mapViewFactory: (Context) -> MapView = { createMapView(it, TileSourceFactory.MAPNIK) },
-    update: (MapView) -> Unit = { updateMapView(it, LAUSANNE_GEO_POINT) }
+    provider: IMapViewProvider<T>
 ) {
     // var trigger by remember { mutableStateOf(...) }
     AndroidView(
         modifier = modifier.testTag("mapViewWrapper"),
-        factory = mapViewFactory,
+        factory = { provider.factory(it) },
         // Function that will be called when the view has been
         // inflated or state read in this function has been updated
         // AndroidView will recompose whenever said state changes
-        update = { updateMapView(it, LAUSANNE_GEO_POINT) }
+        update = { provider.update(it) }
     )
 }

--- a/app/src/main/java/com/github/swent/echo/compose/map/Map.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/Map.kt
@@ -3,52 +3,37 @@ package com.github.swent.echo.compose.map
 import android.content.Context
 import android.view.View
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.viewinterop.AndroidView
 import com.github.swent.echo.data.model.Event
+import com.github.swent.echo.data.model.Location
+
+val MAP_CENTER = Location("Lausanne Center", 46.5197, 6.6323)
+const val DEFAULT_ZOOM = 15.0
 
 @Composable
 fun <T : View> EchoAndroidView(
     modifier: Modifier = Modifier,
     factory: (Context) -> T,
     update: (T, List<Event>, (Event) -> Unit) -> Unit,
-    events: MutableState<List<Event>>,
+    events: List<Event>,
     callback: (Event) -> Unit = {}
 ) {
-    AndroidView(
-        modifier = modifier,
-        factory = factory,
-        update = { update(it, events.value, callback) }
-    )
+    AndroidView(modifier = modifier, factory = factory, update = { update(it, events, callback) })
 }
 
 /**
  * This composable will draw a map that displays events.
  *
- * @param context Needed to initialize the [MapViewProvider][IMapViewProvider]. Can be the activity
- *   itself if this function is called from an activity, or the `current` field of a
- *   [LocalContext][androidx.compose.ui.platform.LocalContext] if it is called from another
- *   composable.
  * @param events The list of events to be displayed by the map. Whenever this list changes, the
- *   event markers in the map will be automatically updated to match the list. Note that this
- *   parameter is a [MutableState] containing a `List`, so the correct way to instantiate it is the
- *   following: `val myEvents = remember { mutableStateOf(emptyList<Event>()) }`. Do NOT use the
- *   `by` keyword. You can then pass it as an argument to this composable. If you want to change the
- *   value stored in the [MutableState] to trigger a redraw of the markers, you can write
- *   `myEvents.value = newEventList`.
+ *   event markers in the map will be automatically updated to match the list.
  * @param callback The function to be called when a marker on the map is clicked on. The [Event]
  *   corresponding to the marker will be passed as an argument to this function.
  */
 @Composable
-fun MapDrawer(
-    modifier: Modifier = Modifier,
-    context: Context,
-    events: MutableState<List<Event>>,
-    callback: (Event) -> Unit = {}
-) {
-    val provider = OsmdroidMapViewProvider(context)
+fun MapDrawer(modifier: Modifier = Modifier, events: List<Event>, callback: (Event) -> Unit = {}) {
+    val provider = MapLibreMapViewProvider()
     EchoAndroidView(
         modifier = modifier.testTag("mapViewWrapper"),
         factory = provider::factory,

--- a/app/src/main/java/com/github/swent/echo/compose/map/Map.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/Map.kt
@@ -1,11 +1,7 @@
 package com.github.swent.echo.compose.map
 
-// osmdroid libraries
-
 import android.view.View
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.viewinterop.AndroidView
@@ -17,8 +13,10 @@ fun updateMapView(view: MapView, newCenter: GeoPoint) {
 }
 
 @Composable
-fun <T : View> MapDrawer(modifier: Modifier = Modifier, provider: IMapViewProvider<T>) {
-    // var trigger by remember { mutableStateOf(...) }
+fun <T : View> MapDrawer(
+    modifier: Modifier = Modifier,
+    provider: IMapViewProvider<T>,
+) {
     AndroidView(
         modifier = modifier.testTag("mapViewWrapper"),
         factory = { provider.factory(it) },

--- a/app/src/main/java/com/github/swent/echo/compose/map/Map.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/Map.kt
@@ -20,7 +20,11 @@ fun <T : View> EchoAndroidView(
     events: List<Event>,
     callback: (Event) -> Unit = {}
 ) {
-    AndroidView(modifier = modifier, factory = factory, update = { update(it, events, callback) })
+    AndroidView(
+        modifier = modifier.testTag("mapViewWrapper"),
+        factory = factory,
+        update = { update(it, events, callback) }
+    )
 }
 
 /**
@@ -33,9 +37,9 @@ fun <T : View> EchoAndroidView(
  */
 @Composable
 fun MapDrawer(modifier: Modifier = Modifier, events: List<Event>, callback: (Event) -> Unit = {}) {
-    val provider = MapLibreMapViewProvider()
+    val provider = OsmdroidMapViewProvider()
     EchoAndroidView(
-        modifier = modifier.testTag("mapViewWrapper"),
+        modifier = modifier,
         factory = provider::factory,
         // Function that will be called when the view has been
         // inflated or state read in this function has been updated

--- a/app/src/main/java/com/github/swent/echo/compose/map/MapLibreMapViewProvider.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/MapLibreMapViewProvider.kt
@@ -1,0 +1,55 @@
+package com.github.swent.echo.compose.map
+
+import android.content.Context
+import com.github.swent.echo.R
+import com.github.swent.echo.data.model.Event
+import org.maplibre.android.MapLibre
+import org.maplibre.android.annotations.MarkerOptions
+import org.maplibre.android.camera.CameraPosition
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapView
+
+class MapLibreMapViewProvider : IMapViewProvider<MapView> {
+
+    private lateinit var mapView: MapView
+
+    private fun drawMarkers(map: MapLibreMap, events: List<Event>) {
+        events.forEach {
+            map.addMarker(
+                MarkerOptions()
+                    .setPosition(LatLng(it.location.lat, it.location.long))
+                    .title(it.title)
+            )
+        }
+    }
+
+    override fun factory(context: Context): MapView {
+        MapLibre.getInstance(context)
+        mapView = MapView(context)
+        // val styleUrl =
+        // "https://api.maptiler.com/maps/streets-v2/style.json?key=8tGwLwPFCHwJ5D8g7pic "
+        val styleUrl =
+            context.getString(R.string.maptiler_base_style_url) +
+                context.getString(R.string.maptiler_api_key)
+        mapView.onCreate(null)
+        mapView.getMapAsync { map ->
+            // Set the style after mapView was loaded
+            map.setStyle(styleUrl) {
+                map.uiSettings.setAttributionMargins(15, 0, 0, 15)
+                // Set the map view center
+                map.cameraPosition =
+                    CameraPosition.Builder()
+                        .target(MAP_CENTER.toLatLng())
+                        .zoom(DEFAULT_ZOOM)
+                        .bearing(2.0)
+                        .build()
+            }
+        }
+        return mapView
+    }
+
+    override fun update(view: MapView, events: List<Event>, callback: (Event) -> Unit) {
+        view.getMapAsync { drawMarkers(it, events) }
+    }
+}

--- a/app/src/main/java/com/github/swent/echo/compose/map/MapLibreMapViewProvider.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/MapLibreMapViewProvider.kt
@@ -27,8 +27,6 @@ class MapLibreMapViewProvider : IMapViewProvider<MapView> {
     override fun factory(context: Context): MapView {
         MapLibre.getInstance(context)
         mapView = MapView(context)
-        // val styleUrl =
-        // "https://api.maptiler.com/maps/streets-v2/style.json?key=8tGwLwPFCHwJ5D8g7pic "
         val styleUrl =
             context.getString(R.string.maptiler_base_style_url) +
                 context.getString(R.string.maptiler_api_key)

--- a/app/src/main/java/com/github/swent/echo/compose/map/OsmdroidMapViewProvider.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/OsmdroidMapViewProvider.kt
@@ -6,38 +6,20 @@ import org.osmdroid.api.IGeoPoint
 import org.osmdroid.config.Configuration
 import org.osmdroid.tileprovider.MapTileProviderBasic
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory
-import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
 
 /**
  * Provides a [MapView] to be displayed by an
  * [AndroidView][androidx.compose.ui.viewinterop.AndroidView].
- *
- * @param initContext An initial [Context] is needed to properly initialize the `osmdroid`
- *   [Configuration]. This can simply be the activity itself if this constructor is called from an
- *   activity, or the [LocalContext][androidx.compose.ui.platform.LocalContext]`.current` if it is
- *   called from a composable.
  */
-open class OsmdroidMapViewProvider(
-    private val initContext: Context,
-) : IMapViewProvider<MapView> {
+class OsmdroidMapViewProvider() : IMapViewProvider<MapView> {
 
     companion object {
         private val tileSource = TileSourceFactory.MAPNIK
-
-        const val ZOOM_DEFAULT = 15.0
-        val LAUSANNE_GEO_POINT = GeoPoint(46.5197, 6.6323)
     }
 
     private lateinit var mapView: MapView
-
-    init {
-        Configuration.getInstance().apply {
-            userAgentValue = initContext.packageName
-            osmdroidBasePath = initContext.cacheDir
-        }
-    }
 
     fun getCenter(): IGeoPoint = mapView.mapCenter
 
@@ -69,19 +51,23 @@ open class OsmdroidMapViewProvider(
     }
 
     override fun factory(context: Context): MapView {
+        Configuration.getInstance().apply {
+            userAgentValue = context.packageName
+            osmdroidBasePath = context.cacheDir
+        }
         mapView =
             MapView(context, MapTileProviderBasic(context)).apply {
                 setTileSource(tileSource)
                 setMultiTouchControls(true)
                 clipToOutline = true
                 // setOnClickListener { ... }
-                controller.setZoom(ZOOM_DEFAULT)
-                controller.setCenter(LAUSANNE_GEO_POINT)
+                controller.setZoom(DEFAULT_ZOOM)
+                controller.setCenter(MAP_CENTER.toGeoPoint())
             }
         return mapView
     }
 
     override fun update(view: MapView, events: List<Event>, callback: (Event) -> Unit) {
-        mapView.apply { drawAllMarkers(events, callback) }
+        view.apply { drawAllMarkers(events, callback) }
     }
 }

--- a/app/src/main/java/com/github/swent/echo/compose/map/OsmdroidMapViewProvider.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/OsmdroidMapViewProvider.kt
@@ -10,10 +10,17 @@ import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
 
+/**
+ * Provides a [MapView] to be displayed by an
+ * [AndroidView][androidx.compose.ui.viewinterop.AndroidView].
+ *
+ * @param initContext An initial [Context] is needed to properly initialize the `osmdroid`
+ *   [Configuration]. This can simply be the activity itself if this constructor is called from an
+ *   activity, or the [LocalContext][androidx.compose.ui.platform.LocalContext]`.current` if it is
+ *   called from a composable.
+ */
 open class OsmdroidMapViewProvider(
     private val initContext: Context,
-    private val markers: List<Event> = emptyList(),
-    private val callback: (Event) -> Unit = {}
 ) : IMapViewProvider<MapView> {
 
     companion object {
@@ -38,8 +45,8 @@ open class OsmdroidMapViewProvider(
 
     fun getClipToOutline() = mapView.clipToOutline
 
-    private fun drawMarker(e: Event) {
-        val marker = Marker(mapView)
+    private fun MapView.drawMarker(e: Event, callback: (Event) -> Unit) {
+        val marker = Marker(this)
         marker.apply {
             setAnchor(Marker.ANCHOR_BOTTOM, Marker.ANCHOR_CENTER)
             // To get an custom marker, use initContext.getDrawable(R.drawable.test_pin)
@@ -53,12 +60,12 @@ open class OsmdroidMapViewProvider(
                 true
             }
         }
-        mapView.overlays.add(marker)
+        overlays.add(marker)
     }
 
-    private fun drawAllMarkers() {
-        markers.forEach { drawMarker(it) }
-        mapView.invalidate()
+    private fun MapView.drawAllMarkers(events: List<Event>, callback: (Event) -> Unit) {
+        events.forEach { drawMarker(it, callback) }
+        invalidate()
     }
 
     override fun factory(context: Context): MapView {
@@ -71,11 +78,10 @@ open class OsmdroidMapViewProvider(
                 controller.setZoom(ZOOM_DEFAULT)
                 controller.setCenter(LAUSANNE_GEO_POINT)
             }
-        drawAllMarkers()
         return mapView
     }
 
-    override fun update(view: MapView) {
-        // view.controller.setCenter(LAUSANNE_GEO_POINT)
+    override fun update(view: MapView, events: List<Event>, callback: (Event) -> Unit) {
+        mapView.apply { drawAllMarkers(events, callback) }
     }
 }

--- a/app/src/main/java/com/github/swent/echo/compose/map/OsmdroidMapViewProvider.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/OsmdroidMapViewProvider.kt
@@ -42,9 +42,11 @@ open class OsmdroidMapViewProvider(
         val marker = Marker(mapView)
         marker.apply {
             setAnchor(Marker.ANCHOR_BOTTOM, Marker.ANCHOR_CENTER)
-            icon = null // initContext.getDrawable(R.drawable.test_pin)
+            // To get an custom marker, use initContext.getDrawable(R.drawable.test_pin)
+            // 'R' refers to com.github.swent.echo.R
+            icon = null
             title = e.title
-            position = GeoPoint(e.location.lat, e.location.long)
+            position = e.location.toGeoPoint()
             setOnMarkerClickListener { _, _ ->
                 // Shows marker title by default
                 callback(e)

--- a/app/src/main/java/com/github/swent/echo/compose/map/OsmdroidMapViewProvider.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/OsmdroidMapViewProvider.kt
@@ -1,0 +1,47 @@
+package com.github.swent.echo.compose.map
+
+import android.content.Context
+import org.osmdroid.config.Configuration
+import org.osmdroid.tileprovider.MapTileProviderBasic
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory
+import org.osmdroid.util.GeoPoint
+import org.osmdroid.views.MapView
+
+open class OsmdroidMapViewProvider(context: Context) : IMapViewProvider<MapView> {
+
+    companion object {
+        private val tileSource = TileSourceFactory.MAPNIK
+
+        const val ZOOM_DEFAULT = 15.0
+        val LAUSANNE_GEO_POINT = GeoPoint(46.5197, 6.6323)
+    }
+
+    private lateinit var mapView: MapView
+
+    init {
+        Configuration.getInstance().apply {
+            userAgentValue = context.packageName
+            osmdroidBasePath = context.cacheDir
+        }
+    }
+
+    override fun factory(context: Context): MapView {
+        mapView = MapView(context, MapTileProviderBasic(context)).apply {
+            setTileSource(tileSource)
+            setMultiTouchControls(true)
+            clipToOutline = true
+            // setOnClickListener { ... }
+            controller.setZoom(ZOOM_DEFAULT)
+            controller.setCenter(LAUSANNE_GEO_POINT)
+        }
+        return mapView
+    }
+
+    override fun update(view: MapView) {
+        //view.controller.setCenter(LAUSANNE_GEO_POINT)
+    }
+
+    fun getCenter() = mapView.mapCenter
+    fun getZoom() = mapView.zoomLevelDouble
+    fun getClipToOutline() = mapView.clipToOutline
+}

--- a/app/src/main/java/com/github/swent/echo/compose/map/OsmdroidMapViewProvider.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/map/OsmdroidMapViewProvider.kt
@@ -26,22 +26,25 @@ open class OsmdroidMapViewProvider(context: Context) : IMapViewProvider<MapView>
     }
 
     override fun factory(context: Context): MapView {
-        mapView = MapView(context, MapTileProviderBasic(context)).apply {
-            setTileSource(tileSource)
-            setMultiTouchControls(true)
-            clipToOutline = true
-            // setOnClickListener { ... }
-            controller.setZoom(ZOOM_DEFAULT)
-            controller.setCenter(LAUSANNE_GEO_POINT)
-        }
+        mapView =
+            MapView(context, MapTileProviderBasic(context)).apply {
+                setTileSource(tileSource)
+                setMultiTouchControls(true)
+                clipToOutline = true
+                // setOnClickListener { ... }
+                controller.setZoom(ZOOM_DEFAULT)
+                controller.setCenter(LAUSANNE_GEO_POINT)
+            }
         return mapView
     }
 
     override fun update(view: MapView) {
-        //view.controller.setCenter(LAUSANNE_GEO_POINT)
+        // view.controller.setCenter(LAUSANNE_GEO_POINT)
     }
 
     fun getCenter() = mapView.mapCenter
+
     fun getZoom() = mapView.zoomLevelDouble
+
     fun getClipToOutline() = mapView.clipToOutline
 }

--- a/app/src/main/java/com/github/swent/echo/data/model/Location.kt
+++ b/app/src/main/java/com/github/swent/echo/data/model/Location.kt
@@ -5,6 +5,7 @@ import org.osmdroid.util.GeoPoint
 
 data class Location(val name: String, val lat: Double, val long: Double) {
     constructor(name: String, point: GeoPoint) : this(name, point.latitude, point.longitude)
+
     constructor(name: String, point: LatLng) : this(name, point.latitude, point.longitude)
     /**
      * Transform this location into a [GeoPoint].

--- a/app/src/main/java/com/github/swent/echo/data/model/Location.kt
+++ b/app/src/main/java/com/github/swent/echo/data/model/Location.kt
@@ -1,13 +1,22 @@
 package com.github.swent.echo.data.model
 
+import org.maplibre.android.geometry.LatLng
 import org.osmdroid.util.GeoPoint
 
 data class Location(val name: String, val lat: Double, val long: Double) {
     constructor(name: String, point: GeoPoint) : this(name, point.latitude, point.longitude)
+    constructor(name: String, point: LatLng) : this(name, point.latitude, point.longitude)
     /**
      * Transform this location into a [GeoPoint].
      *
-     * @return The respective [GeoPoint]
+     * @return The respective [GeoPoint].
      */
     fun toGeoPoint() = GeoPoint(lat, long)
+
+    /**
+     * Transform this location into a [LatLng].
+     *
+     * @return The respective [LatLng].
+     */
+    fun toLatLng() = LatLng(lat, long)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,6 @@
     <string name="register_screen_action_button">Register</string>
     <string name="register_screen_do_you_have_an_account">Do you have an account?</string>
     <string name="register_screen_login_link">Login</string>
+    <string name="maptiler_api_key">8tGwLwPFCHwJ5D8g7pic</string>
+    <string name="maptiler_base_style_url">https://api.maptiler.com/maps/streets-v2/style.json?key=</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "8.3.1"
 hiltNavigationCompose = "1.2.0"
+androidSdk = "11.0.0-pre4"
 kotlinxSerializationJson = "1.6.3"
 ktorClientAndroid = "2.3.9"
 slf4jSimple = "1.7.36"
@@ -22,6 +23,7 @@ hilt = "2.48"
 osmdroidAndroid = "6.1.18"
 
 [libraries]
+android-sdk = { module = "org.maplibre.gl:android-sdk", version.ref = "androidSdk" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 androidx-navigation-testing = { module = "androidx.navigation:navigation-testing", version.ref = "navigationTesting" }


### PR DESCRIPTION
Will close #34. The objective is to abstract the way `MapView`s are provided in order to be able to choose freely between `osmdroid` and `MapLibre` view providers.
Ideally, support for markers will also be added for both `osmdroid` and `MapLibre`.