### PR TITLE
Stay logged in over multiple app restarts

### DIFF
--- a/app/src/androidTest/java/com/github/swent/echo/di/SimpleAuthenticationService.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/di/SimpleAuthenticationService.kt
@@ -17,6 +17,8 @@ class SimpleAuthenticationService @Inject constructor() : AuthenticationService 
     private var email: String? = null
     private var password: String? = null
 
+    override suspend fun initialize() {}
+
     @Composable
     override fun startGoogleSignInCallback(onResult: (NativeSignInResult) -> Unit): () -> Unit {
         return { onResult(NativeSignInResult.Success) }

--- a/app/src/androidTest/java/com/github/swent/echo/di/SimpleAuthenticationService.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/di/SimpleAuthenticationService.kt
@@ -45,7 +45,7 @@ class SimpleAuthenticationService @Inject constructor() : AuthenticationService 
         return AuthenticationResult.Success
     }
 
-    override suspend fun getCurrentUserID(): String? {
+    override fun getCurrentUserID(): String? {
         return userId
     }
 }

--- a/app/src/androidTest/java/com/github/swent/echo/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/ui/navigation/NavigationTest.kt
@@ -24,19 +24,23 @@ class NavigationTest {
         composeTestRule.activity.setContent {
             val navController = rememberNavController()
             val navigationActions = NavigationActions(navController)
-            AppNavigationHost(navController)
+            AppNavigationHost(userIsLoggedIn = false, navController = navController)
             navigationActions.navigateTo(route)
         }
     }
 
     @Test
-    fun shouldShowRegisterScreenAsDefaultRoute() {
-        composeTestRule.activity.setContent {
-            val navController = rememberNavController()
-            AppNavigationHost(navController)
-        }
+    fun shouldShowRegisterScreenWhenTheUserIsNotLoggedIn() {
+        composeTestRule.activity.setContent { AppNavigationHost(userIsLoggedIn = false) }
 
         composeTestRule.onNodeWithTag("register-screen").assertIsDisplayed()
+    }
+
+    @Test
+    fun shouldShowMapScreenWhenTheUserIsLoggedIn() {
+        composeTestRule.activity.setContent { AppNavigationHost(userIsLoggedIn = true) }
+
+        composeTestRule.onNodeWithTag("home_screen").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/main/java/com/github/swent/echo/MainActivity.kt
+++ b/app/src/main/java/com/github/swent/echo/MainActivity.kt
@@ -7,14 +7,24 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import com.github.swent.echo.authentication.AuthenticationService
 import com.github.swent.echo.compose.navigation.AppNavigationHost
 import com.github.swent.echo.ui.theme.EchoTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import kotlinx.coroutines.runBlocking
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject lateinit var authenticationService: AuthenticationService
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // This happens so quickly, I doesn't make sense to show a loading screen.
+        runBlocking { authenticationService.initialize() }
+
         setContent {
             EchoTheme {
                 // A surface container using the 'background' color from the theme
@@ -22,7 +32,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    AppNavigationHost()
+                    AppNavigationHost(userIsLoggedIn = authenticationService.userIsLoggedIn())
                 }
             }
         }

--- a/app/src/main/java/com/github/swent/echo/authentication/AuthenticationService.kt
+++ b/app/src/main/java/com/github/swent/echo/authentication/AuthenticationService.kt
@@ -38,5 +38,5 @@ interface AuthenticationService {
      *
      * @return The current user's ID, or null if the user is not signed in.
      */
-    suspend fun getCurrentUserID(): String?
+    fun getCurrentUserID(): String?
 }

--- a/app/src/main/java/com/github/swent/echo/authentication/AuthenticationService.kt
+++ b/app/src/main/java/com/github/swent/echo/authentication/AuthenticationService.kt
@@ -6,6 +6,9 @@ import io.github.jan.supabase.compose.auth.composable.NativeSignInResult
 /** Service to handle user authentication. */
 interface AuthenticationService {
 
+    /** Initialize the authentication service. */
+    suspend fun initialize()
+
     /**
      * Creates a callback to start the Google sign in flow.
      *
@@ -35,6 +38,9 @@ interface AuthenticationService {
 
     /**
      * Get the current user's ID.
+     *
+     * Should be called after [initialize], otherwise might return null even if there exists an
+     * authenticated user.
      *
      * @return The current user's ID, or null if the user is not signed in.
      */

--- a/app/src/main/java/com/github/swent/echo/authentication/AuthenticationService.kt
+++ b/app/src/main/java/com/github/swent/echo/authentication/AuthenticationService.kt
@@ -45,4 +45,13 @@ interface AuthenticationService {
      * @return The current user's ID, or null if the user is not signed in.
      */
     fun getCurrentUserID(): String?
+
+    /**
+     * Check if the user is logged in.
+     *
+     * @return True if the user is logged in, false otherwise.
+     */
+    fun userIsLoggedIn(): Boolean {
+        return getCurrentUserID() != null
+    }
 }

--- a/app/src/main/java/com/github/swent/echo/authentication/AuthenticationServiceImpl.kt
+++ b/app/src/main/java/com/github/swent/echo/authentication/AuthenticationServiceImpl.kt
@@ -54,7 +54,7 @@ class AuthenticationServiceImpl(
         return supabaseAuthOperation("log out") { auth.signOut() }
     }
 
-    override suspend fun getCurrentUserID(): String? {
+    override fun getCurrentUserID(): String? {
         return auth.currentSessionOrNull()?.user?.id
     }
 

--- a/app/src/main/java/com/github/swent/echo/authentication/AuthenticationServiceImpl.kt
+++ b/app/src/main/java/com/github/swent/echo/authentication/AuthenticationServiceImpl.kt
@@ -25,6 +25,10 @@ class AuthenticationServiceImpl(
         private const val TAG = "AuthenticationServiceImpl"
     }
 
+    override suspend fun initialize() {
+        auth.awaitInitialization()
+    }
+
     @Composable
     override fun startGoogleSignInCallback(onResult: (NativeSignInResult) -> Unit): () -> Unit {
         val action = composeAuth.rememberSignInWithGoogle(onResult)

--- a/app/src/main/java/com/github/swent/echo/compose/navigation/AppNavigationHost.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/navigation/AppNavigationHost.kt
@@ -20,13 +20,14 @@ import com.github.swent.echo.ui.navigation.Routes
  */
 @Composable
 fun AppNavigationHost(
+    userIsLoggedIn: Boolean,
     navController: NavHostController = rememberNavController(),
 ) {
     val navActions = NavigationActions(navController)
 
     NavHost(
         navController = navController,
-        startDestination = Routes.REGISTER.name,
+        startDestination = if (userIsLoggedIn) Routes.MAP.name else Routes.REGISTER.name,
     ) {
         composable(Routes.LOGIN.name) {
             LoginScreen(loginViewModel = hiltViewModel(), navActions = navActions)

--- a/app/src/test/java/com/github/swent/echo/authentication/AuthenticationServiceImplTest.kt
+++ b/app/src/test/java/com/github/swent/echo/authentication/AuthenticationServiceImplTest.kt
@@ -118,9 +118,9 @@ class AuthenticationServiceImplTest {
 
     @Test
     fun `getCurrentUserID should return user id when user is signed in`() {
-        coEvery { authMock.currentSessionOrNull() } returns
+        every { authMock.currentSessionOrNull() } returns
             mockk { every { user } returns mockk { every { id } returns USER_ID } }
-        val result = runBlocking { service.getCurrentUserID() }
+        val result = service.getCurrentUserID()
         assertEquals(USER_ID, result)
     }
 }

--- a/app/src/test/java/com/github/swent/echo/authentication/AuthenticationServiceImplTest.kt
+++ b/app/src/test/java/com/github/swent/echo/authentication/AuthenticationServiceImplTest.kt
@@ -14,6 +14,7 @@ import io.mockk.unmockkStatic
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -49,6 +50,12 @@ class AuthenticationServiceImplTest {
     @After
     fun tearDown() {
         unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `initialize should call awaitInitialization`() {
+        runBlocking { service.initialize() }
+        coVerify { authMock.awaitInitialization() }
     }
 
     @Test
@@ -122,5 +129,18 @@ class AuthenticationServiceImplTest {
             mockk { every { user } returns mockk { every { id } returns USER_ID } }
         val result = service.getCurrentUserID()
         assertEquals(USER_ID, result)
+    }
+
+    @Test
+    fun `userIsLoggedIn should return true when user is signed in`() {
+        every { authMock.currentSessionOrNull() } returns
+            mockk { every { user } returns mockk { every { id } returns USER_ID } }
+        assertTrue(service.userIsLoggedIn())
+    }
+
+    @Test
+    fun `userIsLoggedIn should return false when user is not signed in`() {
+        every { authMock.currentSessionOrNull() } returns null
+        assertFalse(service.userIsLoggedIn())
     }
 }

--- a/app/src/test/java/com/github/swent/echo/fakes/FakeAuthenticationService.kt
+++ b/app/src/test/java/com/github/swent/echo/fakes/FakeAuthenticationService.kt
@@ -24,6 +24,8 @@ class FakeAuthenticationService : AuthenticationService {
         signedInResult.complete(result)
     }
 
+    override suspend fun initialize() {}
+
     @Composable
     override fun startGoogleSignInCallback(onResult: (NativeSignInResult) -> Unit): () -> Unit {
         return { onResult(NativeSignInResult.Success) }

--- a/app/src/test/java/com/github/swent/echo/fakes/FakeAuthenticationService.kt
+++ b/app/src/test/java/com/github/swent/echo/fakes/FakeAuthenticationService.kt
@@ -44,7 +44,7 @@ class FakeAuthenticationService : AuthenticationService {
         return signedInResult.await()
     }
 
-    override suspend fun getCurrentUserID(): String? {
+    override fun getCurrentUserID(): String? {
         return userID
     }
 }


### PR DESCRIPTION
Users won't have to log in every time they start the app.

This requires #82 to be merged first and will close #83. 