### PR TITLE
Add getSubTags to the repository

### DIFF
--- a/app/src/main/java/com/github/swent/echo/data/repository/Repository.kt
+++ b/app/src/main/java/com/github/swent/echo/data/repository/Repository.kt
@@ -18,6 +18,16 @@ interface Repository {
 
     suspend fun getTag(tagId: String): Tag
 
+    /**
+     * Get all sub-tags of a given tag.
+     *
+     * @param tagId The id of the tag.
+     * @return The list of sub-tags.
+     */
+    suspend fun getSubTags(tagId: String): List<Tag> {
+        return emptyList()
+    }
+
     suspend fun getAllTags(): List<Tag>
 
     suspend fun getUserProfile(userId: String): UserProfile

--- a/app/src/test/java/com/github/swent/echo/data/repository/RepositoryTest.kt
+++ b/app/src/test/java/com/github/swent/echo/data/repository/RepositoryTest.kt
@@ -1,0 +1,15 @@
+package com.github.swent.echo.data.repository
+
+import io.mockk.spyk
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class RepositoryTest {
+
+    @Test
+    fun `getSubTags should return an empty list`() {
+        val repository = spyk<Repository>()
+        val subTags = runBlocking { repository.getSubTags("tagId") }
+        assert(subTags.isEmpty())
+    }
+}


### PR DESCRIPTION
I added a default implementation which returns just an empty list. In the future, it will be implemented by the `RepositoryImpl`. At this point, we can remove the default implementation.