### PR TITLE
Adapt the event and tag data class to fit the backend

### DIFF
--- a/app/src/androidTest/java/com/github/swent/echo/compose/components/EventInfoSheetTest.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/compose/components/EventInfoSheetTest.kt
@@ -6,8 +6,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.github.swent.echo.data.model.Association
 import com.github.swent.echo.data.model.Event
+import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
-import com.github.swent.echo.data.model.UserProfile
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import org.hamcrest.CoreMatchers.equalTo
@@ -33,7 +33,7 @@ class EventInfoSheetTest {
             val event =
                 Event(
                     eventId = "1",
-                    creator = UserProfile("1", "Event Creator", null, null, emptySet()),
+                    creator = EventCreator("1", "Event Creator"),
                     organizer = Association("1", "Event Organization", ""),
                     title = "Event Title",
                     description = "Event Description",

--- a/app/src/androidTest/java/com/github/swent/echo/data/repository/datasources/SupabaseTest.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/data/repository/datasources/SupabaseTest.kt
@@ -4,6 +4,7 @@ import com.github.swent.echo.authentication.AuthenticationService
 import com.github.swent.echo.authentication.AuthenticationServiceImpl
 import com.github.swent.echo.data.model.Association
 import com.github.swent.echo.data.model.Event
+import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
 import com.github.swent.echo.data.model.Tag
 import com.github.swent.echo.data.model.UserProfile
@@ -45,7 +46,7 @@ class SupabaseTest {
     private val event =
         Event(
             "3bcf6f25-81d4-4a14-9caa-c05feb593da0",
-            UserProfile("e65e9435-a9f2-4474-be11-9054305f1a54", "", null, null, emptySet()),
+            EventCreator("e65e9435-a9f2-4474-be11-9054305f1a54", ""),
             association,
             "Dummy Event",
             "blabla description",

--- a/app/src/main/java/com/github/swent/echo/data/SampleEvents.kt
+++ b/app/src/main/java/com/github/swent/echo/data/SampleEvents.kt
@@ -3,10 +3,8 @@ package com.github.swent.echo.data
 import com.github.swent.echo.compose.map.MAP_CENTER
 import com.github.swent.echo.data.model.Association
 import com.github.swent.echo.data.model.Event
+import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
-import com.github.swent.echo.data.model.SectionEPFL
-import com.github.swent.echo.data.model.SemesterEPFL
-import com.github.swent.echo.data.model.UserProfile
 import java.time.ZonedDateTime
 
 // This should come from the repository
@@ -15,7 +13,7 @@ val SAMPLE_EVENTS: List<Event> =
     listOf(
         Event(
             eventId = "a",
-            creator = UserProfile("a", "", null, null, emptySet()),
+            creator = EventCreator("a", ""),
             organizer = Association("a", "a", ""),
             title = "Bowling Event",
             description = "",
@@ -29,7 +27,7 @@ val SAMPLE_EVENTS: List<Event> =
         ),
         Event(
             eventId = "b",
-            creator = UserProfile("a", "", null, null, emptySet()),
+            creator = EventCreator("a", ""),
             organizer = Association("a", "a", ""),
             title = "Swimming Event",
             description = "",
@@ -44,7 +42,7 @@ val SAMPLE_EVENTS: List<Event> =
         ),
         Event(
             eventId = "c",
-            creator = UserProfile("b", "Chad", SemesterEPFL.MAN, SectionEPFL.IN, emptySet()),
+            creator = EventCreator("b", "Chad"),
             organizer = Association("B", "EPFL Mewing Group", ""),
             title = "Badminton Tournament",
             description = "Only the greatest humans shall participate. Win... or die.",

--- a/app/src/main/java/com/github/swent/echo/data/model/Event.kt
+++ b/app/src/main/java/com/github/swent/echo/data/model/Event.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Event(
     @SerialName("event_id") val eventId: String,
-    val creator: UserProfile,
+    val creator: EventCreator,
     val organizer: Association?,
     val title: String,
     val description: String,
@@ -24,7 +24,7 @@ data class Event(
         val EMPTY =
             Event(
                 "",
-                UserProfile("", "", null, null, setOf()),
+                EventCreator("", ""),
                 null,
                 "",
                 "",

--- a/app/src/main/java/com/github/swent/echo/data/model/EventCreator.kt
+++ b/app/src/main/java/com/github/swent/echo/data/model/EventCreator.kt
@@ -1,0 +1,16 @@
+package com.github.swent.echo.data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A creator of an event.
+ *
+ * @property userId The ID of the user who created the event.
+ * @property name The name of the creator. This same name as in the [UserProfile] corresponding to
+ *   the [userId].
+ */
+@Serializable
+data class EventCreator(
+    val userId: String,
+    val name: String,
+)

--- a/app/src/main/java/com/github/swent/echo/data/model/Tag.kt
+++ b/app/src/main/java/com/github/swent/echo/data/model/Tag.kt
@@ -3,4 +3,10 @@ package com.github.swent.echo.data.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-@Serializable data class Tag(@SerialName("tag_id") val tagId: String, val name: String)
+@Serializable
+data class Tag(
+    @SerialName("tag_id") val tagId: String,
+    val name: String,
+    @SerialName("parent_id")
+    val parentId: String? = null, // TODO: We might want to remove the default value here...
+)

--- a/app/src/main/java/com/github/swent/echo/data/model/UserProfile.kt
+++ b/app/src/main/java/com/github/swent/echo/data/model/UserProfile.kt
@@ -10,4 +10,6 @@ data class UserProfile(
     val semester: Semester?,
     val section: Section?,
     val tags: Set<Tag>
-)
+) {
+    fun toEventCreator(): EventCreator = EventCreator(userId, name)
+}

--- a/app/src/main/java/com/github/swent/echo/viewmodels/event/EventViewModel.kt
+++ b/app/src/main/java/com/github/swent/echo/viewmodels/event/EventViewModel.kt
@@ -51,7 +51,7 @@ constructor(
                 } else {
                     _event.value =
                         _event.value.copy(
-                            creator = repository.getUserProfile(userid),
+                            creator = repository.getUserProfile(userid).toEventCreator(),
                             organizer = null
                         )
                     _status.value = EventStatus.Modified

--- a/app/src/test/java/com/github/swent/echo/data/repository/RepositoryImplTest.kt
+++ b/app/src/test/java/com/github/swent/echo/data/repository/RepositoryImplTest.kt
@@ -2,6 +2,7 @@ package com.github.swent.echo.data.repository
 
 import com.github.swent.echo.data.model.Association
 import com.github.swent.echo.data.model.Event
+import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
 import com.github.swent.echo.data.model.Tag
 import com.github.swent.echo.data.model.UserProfile
@@ -25,7 +26,7 @@ class RepositoryImplTest {
     private val event =
         Event(
             "testEvent",
-            UserProfile("testCreator", "", null, null, emptySet()),
+            EventCreator("testCreator", ""),
             association,
             "Dummy Event",
             "blabla description",

--- a/app/src/test/java/com/github/swent/echo/viewmodels/event/EventViewModelTest.kt
+++ b/app/src/test/java/com/github/swent/echo/viewmodels/event/EventViewModelTest.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import com.github.swent.echo.data.model.Association
 import com.github.swent.echo.data.model.Event
+import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
 import com.github.swent.echo.data.model.Tag
 import com.github.swent.echo.data.model.UserProfile
@@ -36,7 +37,7 @@ class EventViewModelTest {
     private val TEST_EVENT =
         Event(
             eventId = "testid",
-            creator = UserProfile("testid", "testname", null, null, emptySet()),
+            creator = EventCreator("testid", "testname"),
             organizer = Association("testid", "testname", "testdesc"),
             title = "test title",
             description = "test description",


### PR DESCRIPTION
I added a new `parentId` field to the `Tag`. This is necessary for building the tree structure we want to achieve with the tags.

Also, I simplified the `Event` model. The `creator` is now of type `EventCreator` which has a `userId` and a `name`. The reasoning behind this is, that we don't want to store a full `UserProfile` in the `Event` data class, as the `UserProfile` has many other fields (`semester`, `section`, and `tags`) which are not relevant. Those should be fetched separately by the app if it needs the full profile.