### PR TITLE
Feature/graphic update 2 event info sheet

### DIFF
--- a/app/src/main/java/com/github/swent/echo/compose/components/EventInfoSheet.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/components/EventInfoSheet.kt
@@ -62,9 +62,7 @@ fun EventInfoSheet(
     val context = LocalContext.current
 
     ModalBottomSheet(
-        modifier = Modifier
-            .fillMaxSize()
-            .testTag("event_info_sheet"),
+        modifier = Modifier.fillMaxSize().testTag("event_info_sheet"),
         onDismissRequest = onDismiss,
         sheetState = sheetState,
     ) {
@@ -72,10 +70,9 @@ fun EventInfoSheet(
 
         Box(
             modifier =
-            Modifier
-                .fillMaxWidth()
-                .fillMaxHeight(0.5f)
-                .padding(start = 20.dp, end = 20.dp, top = 0.dp, bottom = 32.dp)
+                Modifier.fillMaxWidth()
+                    .fillMaxHeight(0.5f)
+                    .padding(start = 20.dp, end = 20.dp, top = 0.dp, bottom = 32.dp)
         ) {
             Text(
                 text = event.title,
@@ -85,13 +82,19 @@ fun EventInfoSheet(
             Text(
                 modifier = Modifier.padding(top = 38.dp),
                 text = event.organizer?.name ?: event.creator.name,
-                style = MaterialTheme.typography.titleLarge.copy(color = MaterialTheme.colorScheme.secondary),
+                style =
+                    MaterialTheme.typography.titleLarge.copy(
+                        color = MaterialTheme.colorScheme.secondary
+                    ),
                 maxLines = 1,
             )
             Text(
                 modifier = Modifier.padding(top = 62.dp),
                 text = event.location.name,
-                style = MaterialTheme.typography.titleLarge.copy(color = MaterialTheme.colorScheme.secondary),
+                style =
+                    MaterialTheme.typography.titleLarge.copy(
+                        color = MaterialTheme.colorScheme.secondary
+                    ),
                 maxLines = 1,
             )
             Text(
@@ -105,9 +108,7 @@ fun EventInfoSheet(
                 style = MaterialTheme.typography.bodyLarge
             )
 
-            Row(modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .padding(bottom = 70.dp)) {
+            Row(modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 70.dp)) {
                 // icon of a person
                 Icon(
                     imageVector = Icons.Filled.Face,
@@ -139,11 +140,10 @@ fun EventInfoSheet(
                         .show()
                 },
                 modifier =
-                Modifier
-                    .align(Alignment.BottomCenter)
-                    .padding(bottom = 20.dp)
-                    .width(165.dp)
-                    .testTag("join_button"),
+                    Modifier.align(Alignment.BottomCenter)
+                        .padding(bottom = 20.dp)
+                        .width(165.dp)
+                        .testTag("join_button"),
             ) {
                 Text(
                     text = stringResource(R.string.event_info_sheet_join_event_button_text),

--- a/app/src/main/java/com/github/swent/echo/compose/components/EventInfoSheet.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/components/EventInfoSheet.kt
@@ -1,5 +1,6 @@
 package com.github.swent.echo.compose.components
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -20,6 +21,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -65,6 +67,9 @@ fun EventInfoSheet(
     val displayDay = if (day < 10) "0$day" else day.toString()
     val displayHour = if (hour < 10) "0$hour" else hour.toString()
     val displayDate = "$displayDay/$displayMonth\n$displayHour:$displayMinute"
+
+    // get the context
+    val context = LocalContext.current
 
     ModalBottomSheet(
         modifier = Modifier.fillMaxSize().testTag("event_info_sheet"),
@@ -151,7 +156,15 @@ fun EventInfoSheet(
 
             // button to join the event
             Button(
-                onClick = onJoinButtonPressed,
+                onClick = {
+                    onJoinButtonPressed()
+                    Toast.makeText(
+                            context,
+                            context.getString(R.string.event_successfully_joined),
+                            Toast.LENGTH_SHORT
+                        )
+                        .show()
+                },
                 modifier =
                     Modifier.align(Alignment.BottomCenter)
                         .padding(bottom = 20.dp)

--- a/app/src/main/java/com/github/swent/echo/compose/components/EventInfoSheet.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/components/EventInfoSheet.kt
@@ -1,19 +1,18 @@
 package com.github.swent.echo.compose.components
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Face
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
@@ -21,9 +20,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -64,7 +61,10 @@ fun EventInfoSheet(
     val hour = event.startDate.hour
     val minute = event.startDate.minute
     val displayMonth = if (month < 10) "0$month" else month.toString()
-    val displayDate = "$day/$displayMonth\n$hour:$minute"
+    val displayMinute = if (minute < 10) "0$minute" else minute.toString()
+    val displayDay = if (day < 10) "0$day" else day.toString()
+    val displayHour = if (hour < 10) "0$hour" else hour.toString()
+    val displayDate = "$displayDay/$displayMonth\n$displayHour:$displayMinute"
 
     ModalBottomSheet(
         modifier = Modifier.fillMaxSize().testTag("event_info_sheet"),
@@ -72,6 +72,7 @@ fun EventInfoSheet(
         sheetState = sheetState,
     ) {
         // Sheet content
+
         Box(
             modifier =
                 Modifier.fillMaxWidth()
@@ -88,11 +89,12 @@ fun EventInfoSheet(
             )
             Text(
                 modifier = Modifier.padding(top = 24.dp),
-                text = event.organizer!!.name,
+                text = event.organizer?.name ?: event.creator.name,
                 style =
                     TextStyle(
                         fontSize = 20.sp,
                         fontWeight = FontWeight(600),
+                        color = MaterialTheme.colorScheme.secondary
                     )
             )
             Text(
@@ -102,6 +104,7 @@ fun EventInfoSheet(
                     TextStyle(
                         fontSize = 20.sp,
                         fontWeight = FontWeight(600),
+                        color = MaterialTheme.colorScheme.secondary
                     )
             )
             Text(
@@ -114,7 +117,7 @@ fun EventInfoSheet(
                     )
             )
             Text(
-                modifier = Modifier.padding(top = 100.dp).width(185.dp),
+                modifier = Modifier.padding(top = 100.dp),
                 text = event.description,
                 style =
                     TextStyle(
@@ -122,11 +125,38 @@ fun EventInfoSheet(
                         fontWeight = FontWeight(600),
                     )
             )
+
+            Row(modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 70.dp)) {
+                // icon of a person
+                Icon(
+                    imageVector = Icons.Filled.Face,
+                    contentDescription = "Show people who joined the event",
+                    modifier = Modifier.testTag("people_icon")
+                )
+                // text to show the number of people who joined the event
+                Text(
+                    text =
+                        if (event.maxParticipants <= 0) {
+                            "${event.participantCount}"
+                        } else {
+                            "${event.participantCount}/${event.maxParticipants}"
+                        },
+                    style =
+                        TextStyle(
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight(600),
+                        )
+                )
+            }
+
             // button to join the event
             Button(
                 onClick = onJoinButtonPressed,
                 modifier =
-                    Modifier.align(Alignment.BottomCenter).width(165.dp).testTag("join_button"),
+                    Modifier.align(Alignment.BottomCenter)
+                        .padding(bottom = 20.dp)
+                        .width(165.dp)
+                        .testTag("join_button"),
             ) {
                 Text(
                     text = stringResource(R.string.event_info_sheet_join_event_button_text),
@@ -137,7 +167,7 @@ fun EventInfoSheet(
                         )
                 )
             }
-            // contains the image and the button to show people who have joined the event
+            /* contains the image and the button to show people who have joined the event
             Box(modifier = Modifier.align(Alignment.CenterEnd).width(150.dp).height(200.dp)) {
                 // image of the event
                 val buttonAlignment =
@@ -186,7 +216,7 @@ fun EventInfoSheet(
                             )
                     )
                 }
-            }
+            }*/
         }
     }
 }

--- a/app/src/main/java/com/github/swent/echo/compose/components/EventInfoSheet.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/components/EventInfoSheet.kt
@@ -3,6 +3,7 @@ package com.github.swent.echo.compose.components
 import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -24,19 +25,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.github.swent.echo.R
 import com.github.swent.echo.data.model.Event
+import java.time.format.DateTimeFormatter
 
 /**
  * Bottom sheet that shows the details of an event.
  *
  * @param event the event to show
  * @param onJoinButtonPressed callback to join the event
- * @param onShowPeopleButtonPressed callback to show people who joined the event
  * @param onDismiss callback to dismiss the sheet
  * @param onFullyExtended callback when the sheet is fully extended
  */
@@ -45,7 +43,6 @@ import com.github.swent.echo.data.model.Event
 fun EventInfoSheet(
     event: Event,
     onJoinButtonPressed: () -> Unit,
-    onShowPeopleButtonPressed: () -> Unit,
     onDismiss: () -> Unit,
     onFullyExtended: () -> Unit
 ) {
@@ -58,21 +55,16 @@ fun EventInfoSheet(
         }
 
     // handle the display of the date and time
-    val day = event.startDate.dayOfMonth
-    val month = event.startDate.monthValue
-    val hour = event.startDate.hour
-    val minute = event.startDate.minute
-    val displayMonth = if (month < 10) "0$month" else month.toString()
-    val displayMinute = if (minute < 10) "0$minute" else minute.toString()
-    val displayDay = if (day < 10) "0$day" else day.toString()
-    val displayHour = if (hour < 10) "0$hour" else hour.toString()
-    val displayDate = "$displayDay/$displayMonth\n$displayHour:$displayMinute"
+    val formatter = DateTimeFormatter.ofPattern("dd/MM\nHH:mm")
+    val displayDate = formatter.format(event.startDate)
 
     // get the context
     val context = LocalContext.current
 
     ModalBottomSheet(
-        modifier = Modifier.fillMaxSize().testTag("event_info_sheet"),
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("event_info_sheet"),
         onDismissRequest = onDismiss,
         sheetState = sheetState,
     ) {
@@ -80,64 +72,49 @@ fun EventInfoSheet(
 
         Box(
             modifier =
-                Modifier.fillMaxWidth()
-                    .fillMaxHeight(0.5f)
-                    .padding(start = 20.dp, end = 20.dp, top = 0.dp, bottom = 32.dp)
+            Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.5f)
+                .padding(start = 20.dp, end = 20.dp, top = 0.dp, bottom = 32.dp)
         ) {
             Text(
                 text = event.title,
-                style =
-                    TextStyle(
-                        fontSize = 24.sp,
-                        fontWeight = FontWeight(600),
-                    )
+                style = MaterialTheme.typography.displaySmall,
+                maxLines = 1,
             )
             Text(
-                modifier = Modifier.padding(top = 24.dp),
+                modifier = Modifier.padding(top = 38.dp),
                 text = event.organizer?.name ?: event.creator.name,
-                style =
-                    TextStyle(
-                        fontSize = 20.sp,
-                        fontWeight = FontWeight(600),
-                        color = MaterialTheme.colorScheme.secondary
-                    )
+                style = MaterialTheme.typography.titleLarge.copy(color = MaterialTheme.colorScheme.secondary),
+                maxLines = 1,
             )
             Text(
-                modifier = Modifier.padding(top = 48.dp),
+                modifier = Modifier.padding(top = 62.dp),
                 text = event.location.name,
-                style =
-                    TextStyle(
-                        fontSize = 20.sp,
-                        fontWeight = FontWeight(600),
-                        color = MaterialTheme.colorScheme.secondary
-                    )
+                style = MaterialTheme.typography.titleLarge.copy(color = MaterialTheme.colorScheme.secondary),
+                maxLines = 1,
             )
             Text(
                 modifier = Modifier.align(Alignment.TopEnd),
                 text = displayDate,
-                style =
-                    TextStyle(
-                        fontSize = 24.sp,
-                        fontWeight = FontWeight(600),
-                    )
+                style = MaterialTheme.typography.displaySmall
             )
             Text(
                 modifier = Modifier.padding(top = 100.dp),
                 text = event.description,
-                style =
-                    TextStyle(
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight(600),
-                    )
+                style = MaterialTheme.typography.bodyLarge
             )
 
-            Row(modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 70.dp)) {
+            Row(modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 70.dp)) {
                 // icon of a person
                 Icon(
                     imageVector = Icons.Filled.Face,
                     contentDescription = "Show people who joined the event",
                     modifier = Modifier.testTag("people_icon")
                 )
+                Spacer(modifier = Modifier.width(5.dp))
                 // text to show the number of people who joined the event
                 Text(
                     text =
@@ -146,11 +123,7 @@ fun EventInfoSheet(
                         } else {
                             "${event.participantCount}/${event.maxParticipants}"
                         },
-                    style =
-                        TextStyle(
-                            fontSize = 20.sp,
-                            fontWeight = FontWeight(600),
-                        )
+                    style = MaterialTheme.typography.titleMedium
                 )
             }
 
@@ -166,70 +139,17 @@ fun EventInfoSheet(
                         .show()
                 },
                 modifier =
-                    Modifier.align(Alignment.BottomCenter)
-                        .padding(bottom = 20.dp)
-                        .width(165.dp)
-                        .testTag("join_button"),
+                Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 20.dp)
+                    .width(165.dp)
+                    .testTag("join_button"),
             ) {
                 Text(
                     text = stringResource(R.string.event_info_sheet_join_event_button_text),
-                    style =
-                        TextStyle(
-                            fontSize = 24.sp,
-                            fontWeight = FontWeight(600),
-                        )
+                    style = MaterialTheme.typography.labelLarge
                 )
             }
-            /* contains the image and the button to show people who have joined the event
-            Box(modifier = Modifier.align(Alignment.CenterEnd).width(150.dp).height(200.dp)) {
-                // image of the event
-                val buttonAlignment =
-                    if (event.imageId > 0) {
-                        Alignment.BottomEnd
-                    } else {
-                        Alignment.TopEnd
-                    }
-
-                if (event.imageId > 0) { // if the id is zero or negative, then there is no image
-                    Image(
-                        painter = painterResource(id = event.imageId), // replace with actual image
-                        contentDescription = event.title,
-                        modifier =
-                            Modifier.width(135.dp)
-                                .height(135.dp)
-                                .align(Alignment.TopEnd)
-                                .clip(RoundedCornerShape(8.dp))
-                                .testTag("event_image")
-                    )
-                }
-                // button to show people who joined the event
-                Button(
-                    onClick = onShowPeopleButtonPressed,
-                    modifier =
-                        Modifier.align(buttonAlignment).width(135.dp).testTag("people_button"),
-                ) {
-                    // icon of a person
-                    Icon(
-                        imageVector = Icons.Filled.Face,
-                        contentDescription = "Show people who joined the event",
-                        modifier = Modifier.testTag("people_button_icon")
-                    )
-                    // text to show the number of people who joined the event
-                    Text(
-                        text =
-                            if (event.maxParticipants <= 0) {
-                                "${event.participantCount}"
-                            } else {
-                                "${event.participantCount}/${event.maxParticipants}"
-                            },
-                        style =
-                            TextStyle(
-                                fontSize = 20.sp,
-                                fontWeight = FontWeight(600),
-                            )
-                    )
-                }
-            }*/
         }
     }
 }

--- a/app/src/main/java/com/github/swent/echo/compose/components/HomeScreen.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/components/HomeScreen.kt
@@ -90,7 +90,6 @@ private fun Content(
             EventInfoSheet(
                 event = displayEventInfo!!,
                 onJoinButtonPressed = {},
-                onShowPeopleButtonPressed = {},
                 onDismiss = homeScreenViewModel::clearOverlay,
                 onFullyExtended = {}
             )

--- a/app/src/main/java/com/github/swent/echo/data/SampleEvents.kt
+++ b/app/src/main/java/com/github/swent/echo/data/SampleEvents.kt
@@ -62,7 +62,7 @@ val SAMPLE_EVENTS: List<Event> =
         Event(
             eventId = "d",
             creator = EventCreator("d", "Matt Mercer"),
-            organizer = Association("C", "EPFL D&D club", ""),
+            organizer = null,
             title = "D&D oneshot",
             description = "Come play D&D with us ! We have cookies.",
             location =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,4 +68,5 @@
     <string name="edit_event_screen_confirm_location">OK</string>
     <string name="list_drawer_view_on_map">View On Map</string>
     <string name="list_drawer_join_event">Join Event</string>
+    <string name="event_successfully_joined">Event successfully joined!</string>
 </resources>

--- a/app/src/test/java/com/github/swent/echo/compose/components/EventInfoSheetTest.kt
+++ b/app/src/test/java/com/github/swent/echo/compose/components/EventInfoSheetTest.kt
@@ -23,14 +23,12 @@ class EventInfoSheetTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     private var joinClicked = 0
-    private var peopleClicked = 0
     private var dismissed = 0
     private var extended = 0
 
     private fun setUp(peopleMax: Int = 0) {
         composeTestRule.setContent {
             joinClicked = 0
-            peopleClicked = 0
             dismissed = 0
 
             val event =
@@ -52,7 +50,6 @@ class EventInfoSheetTest {
             EventInfoSheet(
                 event = event,
                 onJoinButtonPressed = { joinClicked++ },
-                onShowPeopleButtonPressed = { peopleClicked++ },
                 onDismiss = { dismissed++ },
                 onFullyExtended = { extended++ }
             )

--- a/app/src/test/java/com/github/swent/echo/compose/components/EventInfoSheetTest.kt
+++ b/app/src/test/java/com/github/swent/echo/compose/components/EventInfoSheetTest.kt
@@ -103,16 +103,9 @@ class EventInfoSheetTest {
     }
 
     @Test
-    fun shouldCallShowPeopleButtonPressedWhenPeopleButtonClicked() {
+    fun shouldShowPeopleIcon() {
         setUp()
-        composeTestRule.onNodeWithTag("people_button").performClick()
-        assertThat(peopleClicked, equalTo(1))
-    }
-
-    @Test
-    fun shouldShowEventImage() {
-        setUp()
-        composeTestRule.onNodeWithTag("event_image").assertExists()
+        composeTestRule.onNodeWithTag("people_icon").assertExists()
     }
 
     @Test


### PR DESCRIPTION
changed the graphical layout of the event info sheet, null organizer now doesn't crash and displays creator name instead. 