### PR TITLE
Always use the `SimpleRepository` in android tests.

### DIFF
--- a/app/src/androidTest/java/com/github/swent/echo/di/FakeRepositoryModule.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/di/FakeRepositoryModule.kt
@@ -1,0 +1,24 @@
+package com.github.swent.echo.di
+
+import com.github.swent.echo.authentication.AuthenticationService
+import com.github.swent.echo.data.repository.Repository
+import com.github.swent.echo.data.repository.SimpleRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import javax.inject.Singleton
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [RepositoryModule::class],
+)
+object FakeRepositoryModule {
+
+    @Singleton
+    @Provides
+    fun provideRepository(authenticationService: AuthenticationService): Repository {
+        return SimpleRepository(authenticationService)
+    }
+}


### PR DESCRIPTION
This makes sure that once we change to the real `Repository` implementation, our android tests won't break/be flaky.