### PR TITLE
add ability to join, leave and get joined events for user to repository and supabase

### DIFF
--- a/app/src/androidTest/java/com/github/swent/echo/data/repository/datasources/SupabaseDataSourceTest.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/data/repository/datasources/SupabaseDataSourceTest.kt
@@ -117,6 +117,24 @@ class SupabaseDataSourceTest {
     }
 
     @Test
+    fun joinEventTest() {
+        val joined = runBlocking { source.joinEvent(userProfile.userId, event.eventId) }
+        assertTrue(joined)
+    }
+
+    @Test
+    fun leaveEventTest() {
+        val left = runBlocking { source.leaveEvent(userProfile.userId, event.eventId) }
+        assertTrue(left)
+    }
+
+    @Test
+    fun getJoinedEventsTest() {
+        val joinedEvents = runBlocking { source.getJoinedEvents(userProfile.userId) }
+        assertEquals(listOf(event.copy(participantCount = 1)), joinedEvents)
+    }
+
+    @Test
     fun getTagTest() {
         val tagFetched = runBlocking { source.getTag("daba142a-a276-4b7e-824d-43ca088633ff") }
         assertEquals(tag, tagFetched)

--- a/app/src/main/java/com/github/swent/echo/data/repository/Repository.kt
+++ b/app/src/main/java/com/github/swent/echo/data/repository/Repository.kt
@@ -29,6 +29,12 @@ interface Repository {
 
     suspend fun getAllEvents(): List<Event>
 
+    suspend fun joinEvent(userId: String, event: Event): Boolean
+
+    suspend fun leaveEvent(userId: String, event: Event): Boolean
+
+    suspend fun getJoinedEvents(userId: String): List<Event>
+
     suspend fun getTag(tagId: String): Tag
 
     /**

--- a/app/src/main/java/com/github/swent/echo/data/repository/RepositoryImpl.kt
+++ b/app/src/main/java/com/github/swent/echo/data/repository/RepositoryImpl.kt
@@ -31,6 +31,18 @@ class RepositoryImpl(private val remoteDataSource: RemoteDataSource) : Repositor
         return remoteDataSource.getAllEvents()
     }
 
+    override suspend fun joinEvent(userId: String, event: Event): Boolean {
+        return remoteDataSource.joinEvent(userId, event.eventId)
+    }
+
+    override suspend fun leaveEvent(userId: String, event: Event): Boolean {
+        return remoteDataSource.leaveEvent(userId, event.eventId)
+    }
+
+    override suspend fun getJoinedEvents(userId: String): List<Event> {
+        return remoteDataSource.getJoinedEvents(userId)
+    }
+
     override suspend fun getTag(tagId: String): Tag {
         return remoteDataSource.getTag(tagId)
     }

--- a/app/src/main/java/com/github/swent/echo/data/repository/SimpleRepository.kt
+++ b/app/src/main/java/com/github/swent/echo/data/repository/SimpleRepository.kt
@@ -24,6 +24,7 @@ class SimpleRepository(authenticationService: AuthenticationService) : Repositor
 
     private val associations = mutableSetOf<Association>()
     private val events = mutableListOf<Event>()
+    private val eventJoins = mutableMapOf<String, List<Event>>()
     private val tags =
         mutableSetOf(
             Tag("1", "Sport", Repository.ROOT_TAG_ID),
@@ -98,6 +99,26 @@ class SimpleRepository(authenticationService: AuthenticationService) : Repositor
 
     override suspend fun getAllEvents(): List<Event> {
         return events
+    }
+
+    override suspend fun joinEvent(userId: String, event: Event): Boolean {
+        val userJoins = eventJoins.get(userId).orEmpty()
+        if (!userJoins.contains(event)) {
+            eventJoins.set(userId, userJoins + event)
+        }
+        return true
+    }
+
+    override suspend fun leaveEvent(userId: String, event: Event): Boolean {
+        val userJoins = eventJoins.get(userId).orEmpty()
+        if (userJoins.contains(event)) {
+            eventJoins.set(userId, userJoins - event)
+        }
+        return true
+    }
+
+    override suspend fun getJoinedEvents(userId: String): List<Event> {
+        return eventJoins.get(userId).orEmpty()
     }
 
     override suspend fun getTag(tagId: String): Tag {

--- a/app/src/main/java/com/github/swent/echo/data/repository/datasources/RemoteDataSource.kt
+++ b/app/src/main/java/com/github/swent/echo/data/repository/datasources/RemoteDataSource.kt
@@ -18,6 +18,12 @@ interface RemoteDataSource {
 
     suspend fun getAllEvents(): List<Event>
 
+    suspend fun joinEvent(userId: String, eventId: String): Boolean
+
+    suspend fun leaveEvent(userId: String, eventId: String): Boolean
+
+    suspend fun getJoinedEvents(userId: String): List<Event>
+
     suspend fun getTag(tagId: String): Tag
 
     suspend fun getSubTags(tagId: String): List<Tag>

--- a/app/src/main/java/com/github/swent/echo/data/supabase/entities/EventJoinSupabase.kt
+++ b/app/src/main/java/com/github/swent/echo/data/supabase/entities/EventJoinSupabase.kt
@@ -1,0 +1,10 @@
+package com.github.swent.echo.data.supabase.entities
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EventJoinSupabase(
+    @SerialName("user_id") val userId: String,
+    @SerialName("event_id") val eventId: String
+)

--- a/app/src/test/java/com/github/swent/echo/data/repository/RepositoryImplTest.kt
+++ b/app/src/test/java/com/github/swent/echo/data/repository/RepositoryImplTest.kt
@@ -90,6 +90,32 @@ class RepositoryImplTest {
     }
 
     @Test
+    fun joinEventTest() {
+        every {
+            runBlocking { mockedRemoteDataSource.joinEvent(userProfile.userId, event.eventId) }
+        } returns true
+        val eventResult = runBlocking { repositoryImpl.joinEvent(userProfile.userId, event) }
+        assertTrue(eventResult)
+    }
+
+    @Test
+    fun leaveEventTest() {
+        every {
+            runBlocking { mockedRemoteDataSource.leaveEvent(userProfile.userId, event.eventId) }
+        } returns true
+        val eventResult = runBlocking { repositoryImpl.leaveEvent(userProfile.userId, event) }
+        assertTrue(eventResult)
+    }
+
+    @Test
+    fun getJoinedEventsTest() {
+        every { runBlocking { mockedRemoteDataSource.getJoinedEvents(userProfile.userId) } } returns
+            Arrays.asList(event)
+        val eventsResult = runBlocking { repositoryImpl.getJoinedEvents(userProfile.userId) }
+        assertEquals(Arrays.asList(event), eventsResult)
+    }
+
+    @Test
     fun getTagTest() {
         every { runBlocking { mockedRemoteDataSource.getTag("testTag") } } returns tag
         val tagResult = runBlocking { repositoryImpl.getTag("testTag") }

--- a/app/src/test/java/com/github/swent/echo/data/repository/SimpleRepositoryTest.kt
+++ b/app/src/test/java/com/github/swent/echo/data/repository/SimpleRepositoryTest.kt
@@ -67,6 +67,21 @@ class SimpleRepositoryTest {
     }
 
     @Test
+    fun `joinEvent and leaveEvent should add and remove Event to list returned by getJoinedEvents`() =
+        runBlocking {
+            val events = simpleRepository.getAllEvents()
+            val event = events.first()
+            val joined = simpleRepository.joinEvent(USER_ID, event)
+            assertTrue(joined)
+            val joinedEvents = simpleRepository.getJoinedEvents(USER_ID)
+            assertEquals(listOf(event), joinedEvents)
+            val left = simpleRepository.leaveEvent(USER_ID, event)
+            assertTrue(left)
+            val joinedEventsAfterLeave = simpleRepository.getJoinedEvents(USER_ID)
+            assertEquals(listOf<Event>(), joinedEventsAfterLeave)
+        }
+
+    @Test
     fun `getTag should return the tag with the given id`() = runBlocking {
         val tags = simpleRepository.getAllTags()
         val expected = tags.first()


### PR DESCRIPTION
works towards closing #192

I've also added corresponding RLS policies on Supabase as well as a Postgrest function as well as triggers to increment/decrement the counter of participants on the corresponding `Event`