### PR TITLE
Fix null user profile bug

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -130,6 +130,7 @@ dependencies {
     testImplementation(libs.slf4j.simple)
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.ui.test.junit4)
+    testImplementation(libs.turbine)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/github/swent/echo/MainActivity.kt
+++ b/app/src/main/java/com/github/swent/echo/MainActivity.kt
@@ -14,7 +14,6 @@ import com.github.swent.echo.data.repository.Repository
 import com.github.swent.echo.ui.theme.EchoTheme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlinx.coroutines.runBlocking
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -25,8 +24,6 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // This happens so quickly, I doesn't make sense to show a loading screen.
-        runBlocking { authenticationService.initialize() }
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
         setContent {
             EchoTheme {
@@ -36,7 +33,6 @@ class MainActivity : ComponentActivity() {
                     color = MaterialTheme.colorScheme.background
                 ) {
                     AppNavigationHost(
-                        userIsLoggedIn = authenticationService.userIsLoggedIn(),
                         authenticationService = authenticationService,
                         repository = repository,
                     )

--- a/app/src/main/java/com/github/swent/echo/compose/authentication/LoadingScreen.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/authentication/LoadingScreen.kt
@@ -1,0 +1,27 @@
+package com.github.swent.echo.compose.authentication
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LoadingScreen() {
+    Column(
+        modifier = Modifier.testTag("LoadingScreen"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.width(64.dp),
+            color = MaterialTheme.colorScheme.secondary,
+            trackColor = MaterialTheme.colorScheme.surfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/com/github/swent/echo/compose/authentication/LoginScreen.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/authentication/LoginScreen.kt
@@ -27,7 +27,9 @@ fun LoginScreen(loginViewModel: LoginViewModel, navActions: NavigationActions) {
     val state by loginViewModel.state.collectAsState()
 
     if (state is AuthenticationState.SignedIn) {
-        LaunchedEffect(state) { navActions.navigateTo(Routes.MAP) }
+        LaunchedEffect(state) {
+            navActions.navigateTo((state as AuthenticationState.SignedIn).redirect)
+        }
     }
 
     Column(

--- a/app/src/main/java/com/github/swent/echo/compose/authentication/RegisterScreen.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/authentication/RegisterScreen.kt
@@ -38,7 +38,7 @@ fun RegisterScreen(registerViewModel: RegisterViewModel, navActions: NavigationA
     if (state is AuthenticationState.SignedIn) {
         LaunchedEffect(state) {
             if (usingGoogleAuthentication) {
-                navActions.navigateTo(Routes.MAP)
+                navActions.navigateTo((state as AuthenticationState.SignedIn).redirect)
             } else {
                 val message = context.getString(R.string.register_screen_confirm_your_email)
                 Toast.makeText(context, message, Toast.LENGTH_LONG).show()

--- a/app/src/main/java/com/github/swent/echo/compose/navigation/AppNavigationHost.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/navigation/AppNavigationHost.kt
@@ -2,6 +2,7 @@ package com.github.swent.echo.compose.navigation
 
 // import com.github.swent.echo.compose.authentication.ProfileCreationScreen
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -10,6 +11,7 @@ import androidx.navigation.compose.rememberNavController
 import com.github.swent.echo.authentication.AuthenticationService
 import com.github.swent.echo.compose.association.AssociationCommitteeMemberScreen
 import com.github.swent.echo.compose.association.AssociationSubscriptionsScreen
+import com.github.swent.echo.compose.authentication.LoadingScreen
 import com.github.swent.echo.compose.authentication.LoginScreen
 import com.github.swent.echo.compose.authentication.ProfileCreationScreen
 import com.github.swent.echo.compose.authentication.RegisterScreen
@@ -28,18 +30,29 @@ import com.github.swent.echo.ui.navigation.Routes
  */
 @Composable
 fun AppNavigationHost(
-    userIsLoggedIn: Boolean,
     navController: NavHostController = rememberNavController(),
     authenticationService: AuthenticationService,
     repository: Repository,
 ) {
     val navActions = NavigationActions(navController, authenticationService, repository)
 
+    // At application start, initialize the authentication service and navigate to the map screen.
+    // The navigation actions will take care of navigating to the correct screen based on the
+    // current user id and its profile.
+    LaunchedEffect(navController) {
+        // Make sure we initialize the authentication service. Otherwise, the current user id will
+        // always be null and the user will always be redirected to the login screen...
+        authenticationService.initialize()
+
+        navActions.navigateTo(Routes.MAP)
+    }
+
     NavHost(
         navController = navController,
-        // startDestination = Routes.PROFILE_CREATION.name,
-        startDestination = if (userIsLoggedIn) Routes.MAP.name else Routes.REGISTER.name,
+        startDestination = Routes.LOADING.name,
     ) {
+        composable(Routes.LOADING.name) { LoadingScreen() }
+
         composable(Routes.LOGIN.name) {
             LoginScreen(loginViewModel = hiltViewModel(), navActions = navActions)
         }

--- a/app/src/main/java/com/github/swent/echo/compose/navigation/AppNavigationHost.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/navigation/AppNavigationHost.kt
@@ -34,17 +34,29 @@ fun AppNavigationHost(
     authenticationService: AuthenticationService,
     repository: Repository,
 ) {
-    val navActions = NavigationActions(navController, authenticationService, repository)
+    val navActions = NavigationActions(navController)
 
     // At application start, initialize the authentication service and navigate to the map screen.
     // The navigation actions will take care of navigating to the correct screen based on the
     // current user id and its profile.
     LaunchedEffect(navController) {
         // Make sure we initialize the authentication service. Otherwise, the current user id will
-        // always be null and the user will always be redirected to the login screen...
+        // always be null.
         authenticationService.initialize()
 
-        navActions.navigateTo(Routes.MAP)
+        // Get the current user id
+        val userId = authenticationService.getCurrentUserID()
+
+        // If the user is not logged in, navigate to the register screen. Else if the user is
+        // logged in but has no profile, navigate to the create profile screen. Otherwise, navigate
+        // to the map screen.
+        if (userId == null) {
+            navActions.navigateTo(Routes.REGISTER)
+        } else if (repository.getUserProfile(userId) == null) {
+            navActions.navigateTo(Routes.PROFILE_CREATION)
+        } else {
+            navActions.navigateTo(Routes.MAP)
+        }
     }
 
     NavHost(

--- a/app/src/main/java/com/github/swent/echo/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/github/swent/echo/ui/navigation/Navigation.kt
@@ -1,9 +1,6 @@
 package com.github.swent.echo.ui.navigation
 
 import androidx.navigation.NavHostController
-import com.github.swent.echo.authentication.AuthenticationService
-import com.github.swent.echo.data.repository.Repository
-import kotlinx.coroutines.runBlocking
 
 /** The routes to the screens of the app */
 data class Routes(val name: String) {
@@ -41,25 +38,10 @@ data class RoutesBuilder(private val route: String, private val argName: String)
  */
 class NavigationActions(
     private val navController: NavHostController,
-    private val authenticationService: AuthenticationService,
-    private val repository: Repository,
 ) {
 
     // navigate to one of the routes available in Routes
     fun navigateTo(route: Routes) {
-        if (route == Routes.MAP) {
-            val userId = authenticationService.getCurrentUserID()
-
-            // If the user is not logged in, navigate to the login screen. Else if the user is
-            // logged in but has no profile, navigate to the create profile screen.
-            if (userId == null) {
-                navigateTo(Routes.LOGIN)
-                return
-            } else if (runBlocking { repository.getUserProfile(userId) } == null) {
-                navigateTo(Routes.PROFILE_CREATION)
-                return
-            }
-        }
         navController.navigate(route.name)
     }
 

--- a/app/src/main/java/com/github/swent/echo/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/github/swent/echo/ui/navigation/Navigation.kt
@@ -10,6 +10,7 @@ data class Routes(val name: String) {
 
     /** The different routes available */
     companion object {
+        val LOADING = Routes("loading")
         val LOGIN = Routes("login")
         val REGISTER = Routes("register")
         val MAP = Routes("map")

--- a/app/src/main/java/com/github/swent/echo/viewmodels/authentication/AbstractAuthenticationViewModel.kt
+++ b/app/src/main/java/com/github/swent/echo/viewmodels/authentication/AbstractAuthenticationViewModel.kt
@@ -2,14 +2,19 @@ package com.github.swent.echo.viewmodels.authentication
 
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.github.swent.echo.authentication.AuthenticationService
+import com.github.swent.echo.data.repository.Repository
+import com.github.swent.echo.ui.navigation.Routes
 import io.github.jan.supabase.compose.auth.composable.NativeSignInResult
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 /** Provides Google sign in functionality. */
 abstract class AbstractAuthenticationViewModel : ViewModel() {
     protected abstract val auth: AuthenticationService
+    protected abstract val repository: Repository
 
     protected val _state = MutableStateFlow<AuthenticationState>(AuthenticationState.SignedOut)
 
@@ -39,7 +44,25 @@ abstract class AbstractAuthenticationViewModel : ViewModel() {
                 _state.value = AuthenticationState.Error("Google sign in failed.")
             is NativeSignInResult.NetworkError ->
                 _state.value = AuthenticationState.Error("A network error occurred.")
-            is NativeSignInResult.Success -> _state.value = AuthenticationState.SignedIn
+            is NativeSignInResult.Success ->
+                viewModelScope.launch {
+                    _state.value = AuthenticationState.SignedIn(getNextRoute())
+                }
+        }
+    }
+
+    /**
+     * Returns the next route depending on the value of the user profile. If the profile is null, it
+     * returns [Routes.PROFILE_CREATION] and [Routes.MAP] otherwise. Note you should only call this
+     * function if the user has sucessfully logged as as it makes the assumption that the user id is
+     * not null.
+     */
+    protected suspend fun getNextRoute(): Routes {
+        val userId = auth.getCurrentUserID()!!
+        return if (repository.getUserProfile(userId) == null) {
+            Routes.PROFILE_CREATION
+        } else {
+            Routes.MAP
         }
     }
 }

--- a/app/src/main/java/com/github/swent/echo/viewmodels/authentication/AuthenticationState.kt
+++ b/app/src/main/java/com/github/swent/echo/viewmodels/authentication/AuthenticationState.kt
@@ -1,12 +1,14 @@
 package com.github.swent.echo.viewmodels.authentication
 
+import com.github.swent.echo.ui.navigation.Routes
+
 /** The possible states of the authentication view models. */
 sealed class AuthenticationState {
     data object SignedOut : AuthenticationState()
 
     data object SigningIn : AuthenticationState()
 
-    data object SignedIn : AuthenticationState()
+    data class SignedIn(val redirect: Routes) : AuthenticationState()
 
     data class Error(val message: String) : AuthenticationState()
 

--- a/app/src/main/java/com/github/swent/echo/viewmodels/authentication/LoginViewModel.kt
+++ b/app/src/main/java/com/github/swent/echo/viewmodels/authentication/LoginViewModel.kt
@@ -3,6 +3,7 @@ package com.github.swent.echo.viewmodels.authentication
 import androidx.lifecycle.viewModelScope
 import com.github.swent.echo.authentication.AuthenticationResult
 import com.github.swent.echo.authentication.AuthenticationService
+import com.github.swent.echo.data.repository.Repository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.launch
@@ -15,9 +16,8 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class LoginViewModel
 @Inject
-constructor(
-    override val auth: AuthenticationService,
-) : AbstractAuthenticationViewModel() {
+constructor(override val auth: AuthenticationService, override val repository: Repository) :
+    AbstractAuthenticationViewModel() {
 
     /**
      * Sign in with email and password.
@@ -29,7 +29,8 @@ constructor(
         _state.value = AuthenticationState.SigningIn
         viewModelScope.launch {
             when (val result = auth.signIn(email, password)) {
-                is AuthenticationResult.Success -> _state.value = AuthenticationState.SignedIn
+                is AuthenticationResult.Success ->
+                    _state.value = AuthenticationState.SignedIn(getNextRoute())
                 is AuthenticationResult.Error ->
                     _state.value = AuthenticationState.Error(result.message)
             }

--- a/app/src/main/java/com/github/swent/echo/viewmodels/authentication/RegisterViewModel.kt
+++ b/app/src/main/java/com/github/swent/echo/viewmodels/authentication/RegisterViewModel.kt
@@ -3,6 +3,7 @@ package com.github.swent.echo.viewmodels.authentication
 import androidx.lifecycle.viewModelScope
 import com.github.swent.echo.authentication.AuthenticationResult
 import com.github.swent.echo.authentication.AuthenticationService
+import com.github.swent.echo.data.repository.Repository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.launch
@@ -15,9 +16,8 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class RegisterViewModel
 @Inject
-constructor(
-    override val auth: AuthenticationService,
-) : AbstractAuthenticationViewModel() {
+constructor(override val auth: AuthenticationService, override val repository: Repository) :
+    AbstractAuthenticationViewModel() {
 
     /**
      * Sign up with email and password.
@@ -29,7 +29,8 @@ constructor(
         _state.value = AuthenticationState.SigningIn
         viewModelScope.launch {
             when (val result = auth.signUp(email, password)) {
-                is AuthenticationResult.Success -> _state.value = AuthenticationState.SignedIn
+                is AuthenticationResult.Success ->
+                    _state.value = AuthenticationState.SignedIn(getNextRoute())
                 is AuthenticationResult.Error ->
                     _state.value = AuthenticationState.Error(result.message)
             }

--- a/app/src/test/java/com/github/swent/echo/compose/authentication/AuthenticationScreenTest.kt
+++ b/app/src/test/java/com/github/swent/echo/compose/authentication/AuthenticationScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.swent.echo.ui.navigation.Routes
 import com.github.swent.echo.viewmodels.authentication.AuthenticationState
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -98,7 +99,7 @@ class AuthenticationScreenTest {
         composeTestRule.setContent {
             AuthenticationScreen(
                 ACTION,
-                AuthenticationState.SignedIn,
+                AuthenticationState.SignedIn(Routes.MAP),
                 this::onAuthenticate,
                 this::shouldHaveSigningInTextWhenIsSigningIn
             )

--- a/app/src/test/java/com/github/swent/echo/ui/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/com/github/swent/echo/ui/navigation/NavigationActionsTest.kt
@@ -1,54 +1,27 @@
 package com.github.swent.echo.ui.navigation
 
 import androidx.navigation.NavHostController
-import com.github.swent.echo.authentication.AuthenticationService
-import com.github.swent.echo.data.model.UserProfile
-import com.github.swent.echo.data.repository.Repository
-import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
 
 class NavigationActionsTest {
-
-    companion object {
-        private const val USER_ID = "1234"
-        private val USER_PROFILE =
-            UserProfile(
-                USER_ID,
-                "John Doe",
-                null,
-                null,
-                emptySet(),
-                emptySet(),
-                emptySet(),
-            )
-    }
-
     private lateinit var navController: NavHostController
     private lateinit var navigationActions: NavigationActions
-    private lateinit var authService: AuthenticationService
-    private lateinit var repository: Repository
 
     @Before
     fun setUp() {
         navController = mockk(relaxed = true)
 
-        authService = mockk()
-        repository = mockk()
-
-        every { authService.getCurrentUserID() } returns USER_ID
-        coEvery { repository.getUserProfile(USER_ID) } returns USER_PROFILE
-
-        navigationActions = NavigationActions(navController, authService, repository)
+        navigationActions = NavigationActions(navController)
     }
 
     @Test
     fun `should navigate to the correct route`() {
         val routes =
             listOf(
+                Routes.LOADING,
                 Routes.LOGIN,
                 Routes.REGISTER,
                 Routes.MAP,
@@ -65,19 +38,5 @@ class NavigationActionsTest {
     fun `should go back to the previous screen`() {
         navigationActions.goBack()
         verify { navController.navigateUp() }
-    }
-
-    @Test
-    fun `should redirect to the home screen when user id is null`() {
-        every { authService.getCurrentUserID() } returns null
-        navigationActions.navigateTo(Routes.MAP)
-        verify { navController.navigate(Routes.LOGIN.name) }
-    }
-
-    @Test
-    fun `should redirect to the create profile screen when user profile is null`() {
-        coEvery { repository.getUserProfile(USER_ID) } returns null
-        navigationActions.navigateTo(Routes.MAP)
-        verify { navController.navigate(Routes.PROFILE_CREATION.name) }
     }
 }

--- a/app/src/test/java/com/github/swent/echo/viewmodels/authentication/LoginViewModelTest.kt
+++ b/app/src/test/java/com/github/swent/echo/viewmodels/authentication/LoginViewModelTest.kt
@@ -1,7 +1,14 @@
 package com.github.swent.echo.viewmodels.authentication
 
+import app.cash.turbine.test
 import com.github.swent.echo.authentication.AuthenticationResult
-import com.github.swent.echo.fakes.FakeAuthenticationService
+import com.github.swent.echo.authentication.AuthenticationService
+import com.github.swent.echo.data.model.UserProfile
+import com.github.swent.echo.data.repository.Repository
+import com.github.swent.echo.ui.navigation.Routes
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -13,18 +20,24 @@ import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class LoginViewModelTest {
-    private lateinit var fakeAuthenticationService: FakeAuthenticationService
+    private lateinit var authenticationService: AuthenticationService
+    private lateinit var repository: Repository
     private lateinit var viewModel: LoginViewModel
 
     companion object {
         private const val EMAIL = "test@email.com"
         private const val PASSWORD = "password"
+        private const val ERROR_MESSAGE = "Error message"
+
+        private val USER_PROFILE =
+            UserProfile("id", "John Doe", null, null, emptySet(), emptySet(), emptySet())
     }
 
     @Before
     fun setUp() {
-        fakeAuthenticationService = FakeAuthenticationService()
-        viewModel = LoginViewModel(fakeAuthenticationService)
+        authenticationService = mockk()
+        repository = mockk()
+        viewModel = LoginViewModel(authenticationService, repository)
     }
 
     @Test
@@ -33,26 +46,56 @@ class LoginViewModelTest {
     }
 
     @Test
-    fun `login should return success when successful`() = runTest {
-        val testDispatcher = UnconfinedTestDispatcher(testScheduler)
-        Dispatchers.setMain(testDispatcher)
+    fun `login should return success with map route when successful and has a user profile`() =
+        runTest {
+            val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+            Dispatchers.setMain(testDispatcher)
 
-        viewModel.login(EMAIL, PASSWORD)
-        assertEquals(AuthenticationState.SigningIn, viewModel.state.value)
-        fakeAuthenticationService.completeSigningOperation(AuthenticationResult.Success)
-        assertEquals(AuthenticationState.SignedIn, viewModel.state.value)
-    }
+            every { authenticationService.getCurrentUserID() } returns USER_PROFILE.userId
+            coEvery { authenticationService.signIn(EMAIL, PASSWORD) } returns
+                AuthenticationResult.Success
+            coEvery { repository.getUserProfile(any()) } returns USER_PROFILE
+
+            viewModel.state.test {
+                assertEquals(AuthenticationState.SignedOut, awaitItem())
+                viewModel.login(EMAIL, PASSWORD)
+                assertEquals(AuthenticationState.SigningIn, awaitItem())
+                assertEquals(AuthenticationState.SignedIn(Routes.MAP), awaitItem())
+            }
+        }
+
+    @Test
+    fun `login should return success with profile creation route when successful and has no user profile`() =
+        runTest {
+            val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+            Dispatchers.setMain(testDispatcher)
+
+            every { authenticationService.getCurrentUserID() } returns USER_PROFILE.userId
+            coEvery { authenticationService.signIn(EMAIL, PASSWORD) } returns
+                AuthenticationResult.Success
+            coEvery { repository.getUserProfile(any()) } returns null
+
+            viewModel.state.test {
+                assertEquals(AuthenticationState.SignedOut, awaitItem())
+                viewModel.login(EMAIL, PASSWORD)
+                assertEquals(AuthenticationState.SigningIn, awaitItem())
+                assertEquals(AuthenticationState.SignedIn(Routes.PROFILE_CREATION), awaitItem())
+            }
+        }
 
     @Test
     fun `login should return error when failed`() = runTest {
         val testDispatcher = UnconfinedTestDispatcher(testScheduler)
         Dispatchers.setMain(testDispatcher)
 
-        viewModel.login(EMAIL, PASSWORD)
-        assertEquals(AuthenticationState.SigningIn, viewModel.state.value)
-        fakeAuthenticationService.completeSigningOperation(
-            AuthenticationResult.Error("Error message")
-        )
-        assertEquals(AuthenticationState.Error("Error message"), viewModel.state.value)
+        coEvery { authenticationService.signIn(EMAIL, PASSWORD) } returns
+            AuthenticationResult.Error(ERROR_MESSAGE)
+
+        viewModel.state.test {
+            assertEquals(AuthenticationState.SignedOut, awaitItem())
+            viewModel.login(EMAIL, PASSWORD)
+            assertEquals(AuthenticationState.SigningIn, awaitItem())
+            assertEquals(AuthenticationState.Error(ERROR_MESSAGE), awaitItem())
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ navigationRuntimeKtx = "2.7.7"
 navigationCompose = "2.7.7"
 navigationTesting = "2.7.7"
 hilt = "2.48"
+turbine = "1.1.0"
 
 [libraries]
 android-sdk = { module = "org.maplibre.gl:android-sdk", version.ref = "androidSdk" }
@@ -64,6 +65,7 @@ androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navig
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This will close #258, the bug the coaches pointed out during the last scrum retrospective.

To solve it, I moved the logic from the `NavigationActions` to the `AppNavHost`. This allows us to do the checks at application start. I added a loading animation to avoid blocking the app during the checks. This will close #105.

Note that as the authentication relied on the `NavigationActions` for navigating to the correct route (profile creation or map), there were some tests which broke. So I had to put some more logic into the authentication view models.