### PR TITLE
Feature/association search

### DIFF
--- a/app/src/main/java/com/github/swent/echo/compose/association/AssociationMainScreen.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/association/AssociationMainScreen.kt
@@ -28,12 +28,11 @@ import androidx.compose.ui.unit.dp
 import com.github.swent.echo.compose.components.ListDrawer
 import com.github.swent.echo.data.model.Association
 import com.github.swent.echo.data.model.Event
-import com.github.swent.echo.viewmodels.association.AssociationPage
 
 @Composable
 fun AssociationMainScreen(
     events: List<Event>,
-    goTo: (AssociationPage) -> Unit,
+    onAssociationClicked: (Association) -> Unit,
     addAssociationToFilter: (Association) -> Unit,
     followedAssociations: List<Association>,
     committeeAssociations: List<Association>,
@@ -43,14 +42,14 @@ fun AssociationMainScreen(
     Column(modifier = Modifier.fillMaxSize().testTag("association_main_screen")) {
         AssociationExpandableList(
             "Followed Associations",
-            goTo,
+            onAssociationClicked,
             addAssociationToFilter,
             followedAssociations,
             eventsFilter
         )
         AssociationExpandableList(
             "My Associations",
-            goTo,
+            onAssociationClicked,
             addAssociationToFilter,
             committeeAssociations,
             eventsFilter
@@ -62,7 +61,7 @@ fun AssociationMainScreen(
 @Composable
 fun AssociationExpandableList(
     title: String,
-    goTo: (AssociationPage) -> Unit,
+    onAssociationClicked: (Association) -> Unit,
     addAssociationToFilter: (Association) -> Unit,
     associationList: List<Association>,
     eventsFilter: List<Association>
@@ -102,11 +101,7 @@ fun AssociationExpandableList(
             AssociationListScreen(
                 associationList,
                 { addAssociationToFilter(it) },
-                {
-                    val nextPage = AssociationPage.DETAILS
-                    nextPage.association = it
-                    goTo(nextPage)
-                },
+                onAssociationClicked,
                 eventsFilter
             )
         }

--- a/app/src/main/java/com/github/swent/echo/compose/association/AssociationScreen.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/association/AssociationScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.res.stringResource
 import com.github.swent.echo.R
 import com.github.swent.echo.compose.components.SearchButton
 import com.github.swent.echo.compose.event.EventTitleAndBackButton
+import com.github.swent.echo.data.model.Association
 import com.github.swent.echo.ui.navigation.NavigationActions
 import com.github.swent.echo.ui.navigation.Routes
 import com.github.swent.echo.viewmodels.association.AssociationOverlay
@@ -42,6 +43,12 @@ fun AssociationScreen(associationViewModel: AssociationViewModel, navActions: Na
         }
     }
 
+    fun onAssociationClicked(association: Association) {
+        val nextPage = AssociationPage.DETAILS
+        nextPage.association = association
+        associationViewModel.goTo(nextPage)
+    }
+
     Scaffold(
         topBar = {
             EventTitleAndBackButton(stringResource(R.string.hamburger_associations)) { goBack() }
@@ -63,7 +70,7 @@ fun AssociationScreen(associationViewModel: AssociationViewModel, navActions: Na
                 AssociationPage.MAINSCREEN -> {
                     AssociationMainScreen(
                         filteredEvents,
-                        { associationViewModel.goTo(it) },
+                        { onAssociationClicked(it) },
                         { associationViewModel.onAssociationToFilterChanged(it) },
                         followedAssociations,
                         committeeAssociations,
@@ -81,7 +88,7 @@ fun AssociationScreen(associationViewModel: AssociationViewModel, navActions: Na
                 }
                 AssociationPage.SEARCH -> {
                     AssociationSearch(
-                        { associationViewModel.goTo(it) },
+                        { onAssociationClicked(it) },
                         associationViewModel.filterAssociations()
                     )
                     if (overlay == AssociationOverlay.SEARCH) {

--- a/app/src/main/java/com/github/swent/echo/compose/association/AssociationSearch.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/association/AssociationSearch.kt
@@ -1,15 +1,23 @@
 package com.github.swent.echo.compose.association
 
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import com.github.swent.echo.data.model.Association
 import com.github.swent.echo.viewmodels.association.AssociationPage
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AssociationSearch(goTo: (AssociationPage) -> Unit, associations: List<Association>) {
-    Text("Association Search", modifier = Modifier.testTag("association_search"))
+    AssociationListScreen(
+        associations,
+        onAssociationClicked = {
+            val nextPage = AssociationPage.DETAILS
+            nextPage.association = it
+            goTo(nextPage)
+        },
+        onRowClicked = {
+            val nextPage = AssociationPage.DETAILS
+            nextPage.association = it
+            goTo(nextPage)
+        },
+        eventsFilter = emptyList()
+    )
 }

--- a/app/src/main/java/com/github/swent/echo/compose/association/AssociationSearch.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/association/AssociationSearch.kt
@@ -2,22 +2,16 @@ package com.github.swent.echo.compose.association
 
 import androidx.compose.runtime.Composable
 import com.github.swent.echo.data.model.Association
-import com.github.swent.echo.viewmodels.association.AssociationPage
 
 @Composable
-fun AssociationSearch(goTo: (AssociationPage) -> Unit, associations: List<Association>) {
+fun AssociationSearch(
+    onAssociationClicked: (Association) -> Unit,
+    associations: List<Association>
+) {
     AssociationListScreen(
         associations,
-        onAssociationClicked = {
-            val nextPage = AssociationPage.DETAILS
-            nextPage.association = it
-            goTo(nextPage)
-        },
-        onRowClicked = {
-            val nextPage = AssociationPage.DETAILS
-            nextPage.association = it
-            goTo(nextPage)
-        },
+        onAssociationClicked = onAssociationClicked,
+        onRowClicked = onAssociationClicked,
         eventsFilter = emptyList()
     )
 }

--- a/app/src/main/java/com/github/swent/echo/compose/association/AssociationSearchBottomSheet.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/association/AssociationSearchBottomSheet.kt
@@ -1,7 +1,21 @@
 package com.github.swent.echo.compose.association
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.github.swent.echo.compose.components.SearchBarTags
+import com.github.swent.echo.compose.components.searchmenu.SearchMenuDiscover
+import com.github.swent.echo.viewmodels.tag.TagViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -10,4 +24,28 @@ fun AssociationSearchBottomSheet(
     onDismiss: () -> Unit,
     searchEntryCallback: (String) -> Unit,
     searched: String
-) {}
+) {
+    val sheetState =
+        rememberModalBottomSheetState(skipPartiallyExpanded = false) { value ->
+            if (value == SheetValue.Expanded) {
+                onFullyExtended()
+            }
+            true
+        }
+    val bottomSheetHeightFraction = 0.5f
+    val paddingInsideBottomSheet = 5.dp
+    ModalBottomSheet(
+        modifier =
+            Modifier.fillMaxWidth()
+                .fillMaxHeight(bottomSheetHeightFraction)
+                .testTag("search_menu_sheet"),
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(modifier = Modifier.padding(paddingInsideBottomSheet)) {
+            SearchBarTags(searched, searchEntryCallback)
+            val tagViewModel: TagViewModel = hiltViewModel()
+            SearchMenuDiscover(searchEntryCallback, tagViewModel)
+        }
+    }
+}

--- a/app/src/test/java/com/github/swent/echo/compose/association/AssociationMainScreenTest.kt
+++ b/app/src/test/java/com/github/swent/echo/compose/association/AssociationMainScreenTest.kt
@@ -54,7 +54,10 @@ class AssociationMainScreenTest {
         composeTestRule.setContent {
             AssociationMainScreen(
                 events = testEvents,
-                goTo = { nextPage = it },
+                onAssociationClicked = {
+                    nextPage = AssociationPage.DETAILS
+                    nextPage.association = it
+                },
                 addAssociationToFilter = { associationToFilter += it },
                 followedAssociations = testAssociations,
                 committeeAssociations = listOf(testAssociations[0]),

--- a/app/src/test/java/com/github/swent/echo/compose/association/AssociationScreenTest.kt
+++ b/app/src/test/java/com/github/swent/echo/compose/association/AssociationScreenTest.kt
@@ -46,6 +46,12 @@ class AssociationScreenTest {
         composeTestRule.onNodeWithTag("association_main_screen").assertExists()
 
         composeTestRule.onNodeWithTag("search_button").performClick()
-        composeTestRule.onNodeWithTag("association_search").assertExists()
+        composeTestRule.onNodeWithTag("association_list_screen").assertExists()
+        composeTestRule.onNodeWithTag("search_menu_sheet").assertExists()
+        composeTestRule.onNodeWithTag("search_menu_search_bar_tags").assertExists()
+        composeTestRule.onNodeWithTag("discover_main_component").assertExists()
+
+        composeTestRule.onNodeWithTag("Back-button").performClick()
+        composeTestRule.onNodeWithTag("association_main_screen").assertExists()
     }
 }

--- a/app/src/test/java/com/github/swent/echo/compose/association/AssociationSearchTest.kt
+++ b/app/src/test/java/com/github/swent/echo/compose/association/AssociationSearchTest.kt
@@ -1,0 +1,53 @@
+package com.github.swent.echo.compose.association
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.viewmodels.association.AssociationPage
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AssociationSearchTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    private var nextPage = AssociationPage.SEARCH
+    private val testAssociation = Association("id 1", "name 1", "description 1")
+
+    @Before
+    fun setup() {
+        nextPage = AssociationPage.SEARCH
+        composeTestRule.setContent {
+            AssociationSearch(
+                {
+                    nextPage = AssociationPage.DETAILS
+                    nextPage.association = it
+                },
+                listOf(testAssociation)
+            )
+        }
+    }
+
+    @Test
+    fun onRowClicked() {
+        composeTestRule.onNodeWithTag("association_list_${testAssociation.name}").performClick()
+        val expectedPage = AssociationPage.DETAILS
+        expectedPage.association = testAssociation
+        assert(nextPage == expectedPage)
+    }
+
+    @Test
+    fun onNameAssociationClicked() {
+        composeTestRule
+            .onNodeWithTag("association_name_button_${testAssociation.name}")
+            .performClick()
+        val expectedPage = AssociationPage.DETAILS
+        expectedPage.association = testAssociation
+        assert(nextPage == expectedPage)
+    }
+}


### PR DESCRIPTION
When the search button is clicked, it opens a bottom sheet with exactly the same functionality as Discover, but without the filters (which doesn't make sense for searching associations). A list with all associations is displayed in the background and updated according to the bottom sheet. If an item of the list is clicked, it leads the user to the specific AssociationPage.