### PR TITLE
Feature/association details

### DIFF
--- a/app/src/main/java/com/github/swent/echo/compose/association/AssociationDetails.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/association/AssociationDetails.kt
@@ -1,18 +1,156 @@
 package com.github.swent.echo.compose.association
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.github.swent.echo.R
+import com.github.swent.echo.compose.components.ListDrawer
 import com.github.swent.echo.data.model.Association
 import com.github.swent.echo.data.model.Event
+
+enum class AssociationDetailsTab {
+    DESCRIPTION,
+    EVENTS
+}
 
 @Composable
 fun AssociationDetails(
     follow: (Association) -> Unit,
     association: Association,
     isFollowed: Boolean,
-    events: List<Event>
+    events: List<Event>,
+    isOnline: Boolean
 ) {
-    Text("Association Details", modifier = Modifier.testTag("association_details"))
+    var associationDetailsTab by remember { mutableStateOf(AssociationDetailsTab.DESCRIPTION) }
+    val paddingValues = 5.dp
+    val followWidth = 150.dp
+    val followHeight = 40.dp
+    val followSpaceInside = 5.dp
+    val verticalSpace = 20.dp
+    val paddingItems = 2.dp
+    val tabHeight = 50.dp
+    val weightItems = 1f
+    val underlineShape = Modifier.height(1.dp).width(200.dp)
+    val underlinePadding = 10.dp
+    Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                association.name,
+                modifier = Modifier.align(Alignment.CenterStart),
+                style = MaterialTheme.typography.titleLarge
+            )
+            Button(
+                enabled = isOnline,
+                onClick = { follow(association) },
+                modifier =
+                    Modifier.align(Alignment.CenterEnd).width(followWidth).height(followHeight)
+            ) {
+                Icon(
+                    if (isFollowed) Icons.Filled.Clear else Icons.Filled.Add,
+                    "Follow/Unfollow association"
+                )
+                Spacer(modifier = Modifier.padding(followSpaceInside))
+                Text(
+                    if (isFollowed) stringResource(R.string.association_details_unfollow)
+                    else stringResource(R.string.association_details_follow)
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(verticalSpace))
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Box(
+                modifier =
+                    Modifier.weight(weightItems).padding(paddingItems).height(tabHeight).clickable {
+                        associationDetailsTab = AssociationDetailsTab.DESCRIPTION
+                    }
+            ) {
+                Text(
+                    stringResource(R.string.association_details_description),
+                    modifier = Modifier.align(Alignment.Center),
+                    style = MaterialTheme.typography.titleSmall
+                )
+            }
+            Box(
+                modifier =
+                    Modifier.weight(weightItems).padding(paddingItems).height(tabHeight).clickable {
+                        associationDetailsTab = AssociationDetailsTab.EVENTS
+                    }
+            ) {
+                Text(
+                    stringResource(R.string.association_details_events),
+                    modifier = Modifier.align(Alignment.Center),
+                    style = MaterialTheme.typography.titleSmall
+                )
+            }
+        }
+        Box(modifier = Modifier.fillMaxWidth()) {
+            when (associationDetailsTab) {
+                AssociationDetailsTab.DESCRIPTION -> {
+                    Box(
+                        modifier =
+                            underlineShape
+                                .align(Alignment.CenterStart)
+                                .padding(start = underlinePadding)
+                                .background(MaterialTheme.colorScheme.primary)
+                                .testTag("my_events_underline_joined_events")
+                    )
+                }
+                AssociationDetailsTab.EVENTS -> {
+                    Box(
+                        modifier =
+                            underlineShape
+                                .align(Alignment.CenterEnd)
+                                .padding(end = underlinePadding)
+                                .background(MaterialTheme.colorScheme.primary)
+                                .testTag("my_events_underline_created_events")
+                    )
+                }
+            }
+        }
+        when (associationDetailsTab) {
+            AssociationDetailsTab.DESCRIPTION -> {
+                Spacer(modifier = Modifier.height(verticalSpace))
+                // Text(association.largeDescription)
+                Text(association.description)
+                /*
+                Spacer(modifier = Modifier.height(verticalSpace))
+                Text(
+                    "Contacts:",
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(5.dp)
+                )
+                Text(association.url, modifier = Modifier.padding(5.dp))
+                 */
+            }
+            AssociationDetailsTab.EVENTS -> {
+                Spacer(modifier = Modifier.height(verticalSpace))
+                ListDrawer(events, "", "", isOnline)
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/github/swent/echo/compose/association/AssociationDetails.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/association/AssociationDetails.kt
@@ -57,7 +57,9 @@ fun AssociationDetails(
     val weightItems = 1f
     val underlineShape = Modifier.height(1.dp).width(200.dp)
     val underlinePadding = 10.dp
-    Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(paddingValues).testTag("association_details")
+    ) {
         Box(modifier = Modifier.fillMaxWidth()) {
             Text(
                 association.name,
@@ -68,7 +70,10 @@ fun AssociationDetails(
                 enabled = isOnline,
                 onClick = { follow(association) },
                 modifier =
-                    Modifier.align(Alignment.CenterEnd).width(followWidth).height(followHeight)
+                    Modifier.align(Alignment.CenterEnd)
+                        .width(followWidth)
+                        .height(followHeight)
+                        .testTag("association_details_follow_button")
             ) {
                 Icon(
                     if (isFollowed) Icons.Filled.Clear else Icons.Filled.Add,
@@ -77,7 +82,8 @@ fun AssociationDetails(
                 Spacer(modifier = Modifier.padding(followSpaceInside))
                 Text(
                     if (isFollowed) stringResource(R.string.association_details_unfollow)
-                    else stringResource(R.string.association_details_follow)
+                    else stringResource(R.string.association_details_follow),
+                    modifier = Modifier.testTag("association_details_follow_button_text")
                 )
             }
         }
@@ -85,9 +91,11 @@ fun AssociationDetails(
         Row(modifier = Modifier.fillMaxWidth()) {
             Box(
                 modifier =
-                    Modifier.weight(weightItems).padding(paddingItems).height(tabHeight).clickable {
-                        associationDetailsTab = AssociationDetailsTab.DESCRIPTION
-                    }
+                    Modifier.weight(weightItems)
+                        .padding(paddingItems)
+                        .height(tabHeight)
+                        .clickable { associationDetailsTab = AssociationDetailsTab.DESCRIPTION }
+                        .testTag("association_details_description_tab")
             ) {
                 Text(
                     stringResource(R.string.association_details_description),
@@ -97,9 +105,11 @@ fun AssociationDetails(
             }
             Box(
                 modifier =
-                    Modifier.weight(weightItems).padding(paddingItems).height(tabHeight).clickable {
-                        associationDetailsTab = AssociationDetailsTab.EVENTS
-                    }
+                    Modifier.weight(weightItems)
+                        .padding(paddingItems)
+                        .height(tabHeight)
+                        .clickable { associationDetailsTab = AssociationDetailsTab.EVENTS }
+                        .testTag("association_details_events_tab")
             ) {
                 Text(
                     stringResource(R.string.association_details_events),
@@ -117,7 +127,7 @@ fun AssociationDetails(
                                 .align(Alignment.CenterStart)
                                 .padding(start = underlinePadding)
                                 .background(MaterialTheme.colorScheme.primary)
-                                .testTag("my_events_underline_joined_events")
+                                .testTag("association_details_underline_description")
                     )
                 }
                 AssociationDetailsTab.EVENTS -> {
@@ -127,7 +137,7 @@ fun AssociationDetails(
                                 .align(Alignment.CenterEnd)
                                 .padding(end = underlinePadding)
                                 .background(MaterialTheme.colorScheme.primary)
-                                .testTag("my_events_underline_created_events")
+                                .testTag("association_details_underline_events")
                     )
                 }
             }
@@ -136,7 +146,10 @@ fun AssociationDetails(
             AssociationDetailsTab.DESCRIPTION -> {
                 Spacer(modifier = Modifier.height(verticalSpace))
                 // Text(association.largeDescription)
-                Text(association.description)
+                Text(
+                    association.description,
+                    modifier = Modifier.testTag("association_details_description_text")
+                )
                 /*
                 Spacer(modifier = Modifier.height(verticalSpace))
                 Text(

--- a/app/src/main/java/com/github/swent/echo/compose/association/AssociationScreen.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/association/AssociationScreen.kt
@@ -84,6 +84,7 @@ fun AssociationScreen(associationViewModel: AssociationViewModel, navActions: Na
                         currentAssociationPage.association,
                         followedAssociations.contains(currentAssociationPage.association),
                         associationViewModel.associationEvents(currentAssociationPage.association),
+                        isOnline
                     )
                 }
                 AssociationPage.SEARCH -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,10 @@
     <string name="association_committee_member_screen_title">Your association memberships</string>
     <string name="my_events_joined_events">Joined Events</string>
     <string name="my_events_created_events">Created Events</string>
+    <string name="association_details_unfollow">Unfollow</string>
+    <string name="association_details_follow">Follow</string>
+    <string name="association_details_description">Description</string>
+    <string name="association_details_events">Events</string>
     <string name="list_drawer_leave_event">Leave Event</string>
     <string name="event_successfully_left">Event successfully left!</string>
 </resources>

--- a/app/src/test/java/com/github/swent/echo/compose/association/AssociationDetailsTest.kt
+++ b/app/src/test/java/com/github/swent/echo/compose/association/AssociationDetailsTest.kt
@@ -1,0 +1,51 @@
+package com.github.swent.echo.compose.association
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.Event
+import com.github.swent.echo.data.model.EventCreator
+import com.github.swent.echo.data.model.Location
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.ZonedDateTime
+
+@RunWith(AndroidJUnit4::class)
+class AssociationDetailsTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val testAssociation = Association("id 1", "name 1", "description 1")
+    private var isFollowed = false
+    private val testEvent = Event(
+        "event 1",
+        EventCreator.EMPTY,
+        testAssociation,
+        "title 1",
+        "",
+        Location.EMPTY,
+        ZonedDateTime.now(),
+        ZonedDateTime.now(),
+        emptySet(),
+        0,
+        0,
+        0
+    )
+
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent {
+            AssociationDetails(
+                { isFollowed = !isFollowed },
+                testAssociation,
+                isFollowed,
+                listOf(testEvent),
+                true
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/github/swent/echo/compose/association/AssociationDetailsTest.kt
+++ b/app/src/test/java/com/github/swent/echo/compose/association/AssociationDetailsTest.kt
@@ -1,51 +1,86 @@
 package com.github.swent.echo.compose.association
 
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.swent.echo.data.model.Association
 import com.github.swent.echo.data.model.Event
 import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
+import java.time.ZonedDateTime
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.time.ZonedDateTime
 
 @RunWith(AndroidJUnit4::class)
 class AssociationDetailsTest {
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
+    @get:Rule val composeTestRule = createComposeRule()
 
     private val testAssociation = Association("id 1", "name 1", "description 1")
-    private var isFollowed = false
-    private val testEvent = Event(
-        "event 1",
-        EventCreator.EMPTY,
-        testAssociation,
-        "title 1",
-        "",
-        Location.EMPTY,
-        ZonedDateTime.now(),
-        ZonedDateTime.now(),
-        emptySet(),
-        0,
-        0,
-        0
-    )
-
+    private var isFollowed = mutableStateOf(false)
+    private val testEvent =
+        Event(
+            "event 1",
+            EventCreator.EMPTY,
+            testAssociation,
+            "title 1",
+            "",
+            Location.EMPTY,
+            ZonedDateTime.now(),
+            ZonedDateTime.now(),
+            emptySet(),
+            0,
+            0,
+            0
+        )
 
     @Before
     fun setUp() {
         composeTestRule.setContent {
             AssociationDetails(
-                { isFollowed = !isFollowed },
+                { isFollowed.value = !isFollowed.value },
                 testAssociation,
-                isFollowed,
+                isFollowed.value,
                 listOf(testEvent),
                 true
             )
         }
+    }
+
+    @Test
+    fun associationDetailsExists() {
+        composeTestRule.onNodeWithTag("association_details").assertExists()
+    }
+
+    @Test
+    fun followButtonWorks() {
+        composeTestRule.onNodeWithTag("association_details_follow_button").performClick()
+        assert(isFollowed.value)
+        composeTestRule
+            .onNodeWithTag("association_details_follow_button_text", useUnmergedTree = true)
+            .assertTextEquals("Unfollow")
+        composeTestRule.onNodeWithTag("association_details_follow_button").performClick()
+        assert(!isFollowed.value)
+        composeTestRule
+            .onNodeWithTag("association_details_follow_button_text", useUnmergedTree = true)
+            .assertTextEquals("Follow")
+    }
+
+    @Test
+    fun associationDetailsTabsWork() {
+        composeTestRule.onNodeWithTag("association_details_events_tab").performClick()
+        composeTestRule.onNodeWithTag("association_details_underline_events").assertExists()
+        composeTestRule.onNodeWithTag("list_drawer").assertExists()
+
+        composeTestRule.onNodeWithTag("association_details_description_tab").performClick()
+        composeTestRule.onNodeWithTag("association_details_underline_description").assertExists()
+        composeTestRule
+            .onNodeWithTag("association_details_description_text", useUnmergedTree = true)
+            .assertTextEquals(testAssociation.description)
     }
 }


### PR DESCRIPTION
On top, we have the choice of two pages : a "Description" default page and a "Events" page.

Description
This page consists of the title and description of the association. On top right, there is a button to follow/unfollow the association.

Events
This page shows all events of the association. Reuse the ListDrawer already implemented in HomeScreen, filtered to display only events of the association.