### PR TITLE
🐛 HIGH VALUE BUGFIX AFTER 3 HOURS OF DEBUGGING: properly refetch events *after* joining/leaving event 

### DIFF
--- a/app/src/main/java/com/github/swent/echo/compose/components/JoinEventButton.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/components/JoinEventButton.kt
@@ -20,10 +20,7 @@ fun JoinEventButton(event: Event, isOnline: Boolean, buttonWidth: Dp, refreshEve
     val joinedEvents by myEventsViewModel.joinedEvents.collectAsState()
     Button(
         enabled = isOnline && (event.participantCount < event.maxParticipants),
-        onClick = {
-            myEventsViewModel.joinOrLeaveEvent(event)
-            refreshEvents()
-        },
+        onClick = { myEventsViewModel.joinOrLeaveEvent(event, refreshEvents) },
         modifier =
             androidx.compose.ui.Modifier.width(buttonWidth)
                 .testTag("list_join_event_${event.eventId}")

--- a/app/src/main/java/com/github/swent/echo/viewmodels/HomeScreenViewModel.kt
+++ b/app/src/main/java/com/github/swent/echo/viewmodels/HomeScreenViewModel.kt
@@ -380,6 +380,8 @@ constructor(
     fun refreshEvents() {
         viewModelScope.launch {
             allEventsList = repository.getAllEvents()
+            _displayEventInfo.value =
+                allEventsList.find { it.eventId == displayEventInfo.value?.eventId }
             filterEvents()
         }
     }

--- a/app/src/main/java/com/github/swent/echo/viewmodels/myevents/MyEventsViewModel.kt
+++ b/app/src/main/java/com/github/swent/echo/viewmodels/myevents/MyEventsViewModel.kt
@@ -32,7 +32,7 @@ constructor(
         }
     }
 
-    fun joinOrLeaveEvent(event: Event) {
+    fun joinOrLeaveEvent(event: Event, onFinished: () -> Unit) {
         viewModelScope.launch {
             if (_joinedEvents.value.map { it.eventId }.contains(event.eventId)) {
                 repository.leaveEvent(user, event)
@@ -40,6 +40,7 @@ constructor(
                 repository.joinEvent(user, event)
             }
             _joinedEvents.value = repository.getJoinedEvents(user)
+            onFinished()
         }
     }
 


### PR DESCRIPTION
After spending 3 hours debugging why #313 didn't have it's intended effect when taken together with #310, I finally figured out how to make this work thanks to the help of @unglazedstamp 

The refresh action being launched in it's own coroutine, it refreshed the viewmodel before the coroutine which made the call to the repository for joining/leaving (which updates the even in the cache) finished. Therefore the applied changes were not visible. This change makes sure the refresh of the viewmodel and consequently the UI state is only done after the call to the repository finished.

~:warning: requires #310 to be merged first -> only look at the last commit for now.~ EDIT: merged