### PR TITLE
Imporve register UX

### DIFF
--- a/app/src/androidTest/java/com/github/swent/echo/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/MainActivityTest.kt
@@ -58,6 +58,7 @@ class MainActivityTest {
     @Test
     fun shouldNavigateToLoginRouteWhenLoginButtonIsClicked() {
         // Navigate to the login screen
+        composeTestRule.onNodeWithTag("login-button").performScrollTo()
         composeTestRule.onNodeWithTag("login-button").performClick()
         composeTestRule.onNodeWithTag("login-screen").assertIsDisplayed()
     }
@@ -65,6 +66,7 @@ class MainActivityTest {
     @Test
     fun shouldNavigateBackToRegisterRouteWhenRegisterButtonIsClicked() {
         // Navigate to the login screen
+        composeTestRule.onNodeWithTag("login-button").performScrollTo()
         composeTestRule.onNodeWithTag("login-button").performClick()
         // Navigate back to the register screen
         composeTestRule.onNodeWithTag("register-button").performClick()
@@ -77,6 +79,7 @@ class MainActivityTest {
         composeTestRule.onNodeWithTag("register-screen").assertIsDisplayed()
         composeTestRule.onNodeWithTag("email-field").performTextInput(EMAIL)
         composeTestRule.onNodeWithTag("password-field").performTextInput(PASSWORD)
+        composeTestRule.onNodeWithTag("confirm-password-field").performTextInput(PASSWORD)
         composeTestRule.onNodeWithTag("action-button").performClick()
 
         // Login with the registered user
@@ -130,6 +133,7 @@ class MainActivityTest {
         composeTestRule.onNodeWithTag("register-screen").assertIsDisplayed()
 
         // Go to the login screen
+        composeTestRule.onNodeWithTag("login-button").performScrollTo()
         composeTestRule.onNodeWithTag("login-button").performClick()
 
         // Login with email and password

--- a/app/src/main/java/com/github/swent/echo/compose/authentication/AuthenticationForm.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/authentication/AuthenticationForm.kt
@@ -25,6 +25,12 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.github.swent.echo.R
 
+enum class AuthenticationFormError(val id: Int) {
+    EMPTY_EMAIL(R.string.authentication_error_email_is_required),
+    PASSWORD_TOO_SHORT(R.string.authentication_password_too_short),
+    PASSWORD_DO_NOT_MATCH(R.string.authentication_error_passwords_do_not_match),
+}
+
 /**
  * A form for authenticating a user. It contains fields for the user's email and password.
  *
@@ -53,6 +59,13 @@ fun AuthenticationForm(
     var passwordError by remember { mutableStateOf("") }
     var confirmError by remember { mutableStateOf("") }
 
+    val minPasswordLength = 8
+    val spaceBetweenTextFields = 8.dp
+
+    val emailErrorText = stringResource(AuthenticationFormError.EMPTY_EMAIL.id)
+    val passwordTooShort = stringResource(AuthenticationFormError.PASSWORD_TOO_SHORT.id)
+    val passwordDoNotMatch = stringResource(AuthenticationFormError.PASSWORD_DO_NOT_MATCH.id)
+
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -67,7 +80,7 @@ fun AuthenticationForm(
             },
             errorText = emailError,
         )
-        Spacer(modifier = Modifier.padding(8.dp))
+        Spacer(modifier = Modifier.padding(spaceBetweenTextFields))
         AuthenticationTextField(
             modifier = Modifier.fillMaxWidth().testTag("password-field"),
             label = stringResource(R.string.authentication_form_password_label),
@@ -80,7 +93,7 @@ fun AuthenticationForm(
             isPasswordField = true,
         )
         if (confirmPassword) {
-            Spacer(modifier = Modifier.padding(8.dp))
+            Spacer(modifier = Modifier.padding(spaceBetweenTextFields))
             AuthenticationTextField(
                 modifier = Modifier.fillMaxWidth().testTag("confirm-password-field"),
                 label = stringResource(R.string.authentication_form_confirm_password_label),
@@ -93,25 +106,30 @@ fun AuthenticationForm(
                 isPasswordField = true,
             )
         }
-        Spacer(modifier = Modifier.padding(8.dp))
+        Spacer(modifier = Modifier.padding(spaceBetweenTextFields))
         ElevatedButton(
             enabled = isOnline,
             modifier = Modifier.fillMaxWidth().testTag("action-button"),
             onClick = {
                 if (validate) {
+                    var hasError = false
+
                     if (email.isEmpty()) {
-                        emailError = "Email is required"
+                        emailError = emailErrorText
+                        hasError = true
                     }
 
-                    if (password.length < 8) {
-                        passwordError = "Password must be at least 8 characters"
+                    if (password.length < minPasswordLength) {
+                        passwordError = passwordTooShort
+                        hasError = true
                     }
 
                     if (confirmPassword && password != confirm && passwordError.isEmpty()) {
-                        confirmError = "Passwords do not match"
+                        confirmError = passwordDoNotMatch
+                        hasError = true
                     }
 
-                    if (emailError.isEmpty() && passwordError.isEmpty() && confirmError.isEmpty()) {
+                    if (!hasError) {
                         onAuthenticate(email, password)
                     }
                 } else {
@@ -133,6 +151,8 @@ fun AuthenticationTextField(
     onValueChange: (String) -> Unit,
     isPasswordField: Boolean = false,
 ) {
+    val spaceBetweenErrorText = 4.dp
+
     Column {
         OutlinedTextField(
             modifier = modifier,
@@ -152,7 +172,7 @@ fun AuthenticationTextField(
             singleLine = true,
         )
         if (errorText.isNotEmpty()) {
-            Spacer(modifier = Modifier.padding(4.dp))
+            Spacer(modifier = Modifier.padding(spaceBetweenErrorText))
             Text(
                 text = errorText,
                 color = MaterialTheme.colorScheme.error,

--- a/app/src/main/java/com/github/swent/echo/compose/authentication/AuthenticationForm.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/authentication/AuthenticationForm.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,8 +18,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.github.swent.echo.R
 
@@ -28,47 +31,133 @@ import com.github.swent.echo.R
  * @param action The text to be displayed on the action button.
  * @param onAuthenticate The callback to be invoked when the user clicks the action button. It
  *   receives the user's email and password as parameters.
+ * @param isOnline A boolean indicating whether the user is online.
+ * @param confirmPassword A boolean indicating whether the form should contain a field for
+ *   confirming the password.
+ * @param validate A boolean indicating whether the form should validate the input before calling
+ *   the [onAuthenticate] callback.
  */
 @Composable
 fun AuthenticationForm(
     action: String,
     onAuthenticate: (email: String, password: String) -> Unit,
     isOnline: Boolean,
+    confirmPassword: Boolean = false,
+    validate: Boolean = false,
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
+    var confirm by remember { mutableStateOf("") }
+
+    var emailError by remember { mutableStateOf("") }
+    var passwordError by remember { mutableStateOf("") }
+    var confirmError by remember { mutableStateOf("") }
 
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        OutlinedTextField(
+        AuthenticationTextField(
             modifier = Modifier.fillMaxWidth().testTag("email-field"),
-            label = { Text(stringResource(R.string.authentication_form_email_label)) },
+            label = stringResource(R.string.authentication_form_email_label),
             value = email,
-            onValueChange = { email = it },
-            singleLine = true
+            onValueChange = {
+                emailError = ""
+                email = it
+            },
+            errorText = emailError,
         )
-        Spacer(modifier = Modifier.padding(16.dp))
-        OutlinedTextField(
+        Spacer(modifier = Modifier.padding(8.dp))
+        AuthenticationTextField(
             modifier = Modifier.fillMaxWidth().testTag("password-field"),
-            label = { Text(stringResource(R.string.authentication_form_password_label)) },
+            label = stringResource(R.string.authentication_form_password_label),
             value = password,
-            onValueChange = { password = it },
-            visualTransformation = PasswordVisualTransformation(),
-            keyboardOptions =
-                KeyboardOptions(
-                    keyboardType = KeyboardType.Password,
-                ),
-            singleLine = true
+            onValueChange = {
+                passwordError = ""
+                password = it
+            },
+            errorText = passwordError,
+            isPasswordField = true,
         )
-        Spacer(modifier = Modifier.padding(16.dp))
+        if (confirmPassword) {
+            Spacer(modifier = Modifier.padding(8.dp))
+            AuthenticationTextField(
+                modifier = Modifier.fillMaxWidth().testTag("confirm-password-field"),
+                label = stringResource(R.string.authentication_form_confirm_password_label),
+                value = confirm,
+                onValueChange = {
+                    confirmError = ""
+                    confirm = it
+                },
+                errorText = confirmError,
+                isPasswordField = true,
+            )
+        }
+        Spacer(modifier = Modifier.padding(8.dp))
         ElevatedButton(
             enabled = isOnline,
             modifier = Modifier.fillMaxWidth().testTag("action-button"),
-            onClick = { onAuthenticate(email, password) },
+            onClick = {
+                if (validate) {
+                    if (email.isEmpty()) {
+                        emailError = "Email is required"
+                    }
+
+                    if (password.length < 8) {
+                        passwordError = "Password must be at least 8 characters"
+                    }
+
+                    if (confirmPassword && password != confirm && passwordError.isEmpty()) {
+                        confirmError = "Passwords do not match"
+                    }
+
+                    if (emailError.isEmpty() && passwordError.isEmpty() && confirmError.isEmpty()) {
+                        onAuthenticate(email, password)
+                    }
+                } else {
+                    onAuthenticate(email, password)
+                }
+            },
         ) {
             Text(action)
+        }
+    }
+}
+
+@Composable
+fun AuthenticationTextField(
+    modifier: Modifier,
+    label: String,
+    value: String,
+    errorText: String,
+    onValueChange: (String) -> Unit,
+    isPasswordField: Boolean = false,
+) {
+    Column {
+        OutlinedTextField(
+            modifier = modifier,
+            label = { Text(label) },
+            value = value,
+            onValueChange = onValueChange,
+            isError = errorText.isNotEmpty(),
+            visualTransformation =
+                if (isPasswordField) PasswordVisualTransformation() else VisualTransformation.None,
+            keyboardOptions =
+                if (isPasswordField)
+                    KeyboardOptions(
+                        keyboardType = KeyboardType.Password,
+                        imeAction = ImeAction.Next
+                    )
+                else KeyboardOptions(keyboardType = KeyboardType.Text, imeAction = ImeAction.Next),
+            singleLine = true,
+        )
+        if (errorText.isNotEmpty()) {
+            Spacer(modifier = Modifier.padding(4.dp))
+            Text(
+                text = errorText,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+            )
         }
     }
 }

--- a/app/src/main/java/com/github/swent/echo/compose/authentication/AuthenticationScreen.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/authentication/AuthenticationScreen.kt
@@ -43,7 +43,9 @@ fun AuthenticationScreen(
     state: AuthenticationState,
     isOnline: Boolean,
     onAuthenticate: (email: String, password: String) -> Unit,
-    onStartGoogleSignIn: () -> Unit
+    onStartGoogleSignIn: () -> Unit,
+    confirmPassword: Boolean = false,
+    validate: Boolean = false,
 ) {
     Box(modifier = Modifier.padding(24.dp)) {
         when (state) {
@@ -56,6 +58,8 @@ fun AuthenticationScreen(
                         action = action,
                         isOnline = isOnline,
                         onAuthenticate = onAuthenticate,
+                        confirmPassword = confirmPassword,
+                        validate = validate,
                     )
                     AuthenticationMethodSeparator()
                     GoogleSignInButton(isOnline, onStartGoogleSignIn)

--- a/app/src/main/java/com/github/swent/echo/compose/authentication/LoginScreen.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/authentication/LoginScreen.kt
@@ -4,7 +4,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -33,8 +36,10 @@ fun LoginScreen(loginViewModel: LoginViewModel, navActions: NavigationActions) {
         }
     }
 
+    val scrollState = rememberScrollState()
+
     Column(
-        modifier = Modifier.testTag("login-screen"),
+        modifier = Modifier.testTag("login-screen").fillMaxHeight().verticalScroll(scrollState),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.SpaceBetween,
     ) {

--- a/app/src/main/java/com/github/swent/echo/compose/authentication/RegisterScreen.kt
+++ b/app/src/main/java/com/github/swent/echo/compose/authentication/RegisterScreen.kt
@@ -5,7 +5,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -48,8 +51,10 @@ fun RegisterScreen(registerViewModel: RegisterViewModel, navActions: NavigationA
         }
     }
 
+    val scrollState = rememberScrollState()
+
     Column(
-        modifier = Modifier.testTag("register-screen"),
+        modifier = Modifier.testTag("register-screen").fillMaxHeight().verticalScroll(scrollState),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
@@ -61,6 +66,8 @@ fun RegisterScreen(registerViewModel: RegisterViewModel, navActions: NavigationA
         AuthenticationScreen(
             action = stringResource(R.string.register_screen_action_button),
             isOnline = isOnline,
+            confirmPassword = true,
+            validate = true,
             state = state,
             onAuthenticate = registerViewModel::register,
             onStartGoogleSignIn = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,5 +122,8 @@
     <string name="help_screen_list_mode">It\'s hard to see the events on the map</string>
     <string name="help_screen_list_mode_description">No worries! You can change the display of events to a list by clicking the button in the upper right of the screen. You can even sort it by date or distance!</string>
     <string name="associations_categories">Associations/Categories</string>
+    <string name="authentication_error_email_is_required">Email is required</string>
+    <string name="authentication_password_too_short">Password must be at least 8 characters</string>
+    <string name="authentication_error_passwords_do_not_match">Passwords do not match</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="google_web_client_id">442952145416-mfuc6f0h27oa7efapkrto4veguk0e62u.apps.googleusercontent.com</string>
     <string name="authentication_form_email_label">Email</string>
     <string name="authentication_form_password_label">Password</string>
+    <string name="authentication_form_confirm_password_label">Confirm password</string>
     <string name="authentication_screen_sign_in_with_google">Sign in with Google</string>
     <string name="authentication_screen_google_logo_description">Google Logo</string>
     <string name="authentication_screen_sign_in_method_separator">OR</string>

--- a/app/src/test/java/com/github/swent/echo/compose/authentication/RegisterScreenTest.kt
+++ b/app/src/test/java/com/github/swent/echo/compose/authentication/RegisterScreenTest.kt
@@ -1,9 +1,12 @@
 package com.github.swent.echo.compose.authentication
 
 import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.swent.echo.ui.navigation.NavigationActions
@@ -50,6 +53,7 @@ class RegisterScreenTest {
         state.value = AuthenticationState.SignedOut
         composeTestRule.onNodeWithTag("email-field").performTextInput("test@test.test")
         composeTestRule.onNodeWithTag("password-field").performTextInput("password")
+        composeTestRule.onNodeWithTag("confirm-password-field").performTextInput("password")
         composeTestRule.onNodeWithTag("action-button").performClick()
         verify { registerViewModel.register("test@test.test", "password") }
     }
@@ -59,6 +63,7 @@ class RegisterScreenTest {
         state.value = AuthenticationState.Error("Error message")
         composeTestRule.onNodeWithTag("email-field").performTextInput("test@test.test")
         composeTestRule.onNodeWithTag("password-field").performTextInput("password")
+        composeTestRule.onNodeWithTag("confirm-password-field").performTextInput("password")
         composeTestRule.onNodeWithTag("action-button").performClick()
         verify { registerViewModel.register("test@test.test", "password") }
     }
@@ -66,6 +71,7 @@ class RegisterScreenTest {
     @Test
     fun shouldCallNavigateToLoginWhenLoginButtonIsClickedInSignedOutState() {
         state.value = AuthenticationState.SignedOut
+        composeTestRule.onNodeWithTag("login-button").performScrollTo()
         composeTestRule.onNodeWithTag("login-button").performClick()
         verify { navActions.navigateTo(Routes.LOGIN) }
     }
@@ -73,7 +79,37 @@ class RegisterScreenTest {
     @Test
     fun shouldCallNavigateToLoginWhenLoginButtonIsClickedInErrorState() {
         state.value = AuthenticationState.Error("Error message")
+        composeTestRule.onNodeWithTag("login-button").performScrollTo()
         composeTestRule.onNodeWithTag("login-button").performClick()
         verify { navActions.navigateTo(Routes.LOGIN) }
+    }
+
+    @Test
+    fun shouldDisplayErrorMessageWhenPasswordDoNotMatch() {
+        state.value = AuthenticationState.SignedOut
+        composeTestRule.onNodeWithTag("email-field").performTextInput("test@test.test")
+        composeTestRule.onNodeWithTag("password-field").performTextInput("password")
+        composeTestRule.onNodeWithTag("confirm-password-field").performTextInput("pass")
+        composeTestRule.onNodeWithTag("action-button").performClick()
+        composeTestRule.onNodeWithText("Passwords do not match").assertIsDisplayed()
+    }
+
+    @Test
+    fun shouldDisplayErrorMessageWhenPasswordIsTooShort() {
+        state.value = AuthenticationState.SignedOut
+        composeTestRule.onNodeWithTag("email-field").performTextInput("test@test.test")
+        composeTestRule.onNodeWithTag("password-field").performTextInput("pass")
+        composeTestRule.onNodeWithTag("confirm-password-field").performTextInput("pass")
+        composeTestRule.onNodeWithTag("action-button").performClick()
+        composeTestRule.onNodeWithText("Password must be at least 8 characters").assertIsDisplayed()
+    }
+
+    @Test
+    fun shouldDisplayErrorMessageWhenEmailIsEmpty() {
+        state.value = AuthenticationState.SignedOut
+        composeTestRule.onNodeWithTag("password-field").performTextInput("password")
+        composeTestRule.onNodeWithTag("confirm-password-field").performTextInput("password")
+        composeTestRule.onNodeWithTag("action-button").performClick()
+        composeTestRule.onNodeWithText("Email is required").assertIsDisplayed()
     }
 }


### PR DESCRIPTION
- Added a confirm-password field to better distinguish between the login and register screen. Closes #101.
- Added validation and error texts for the register screen.
- Pressing enter moves to the next text field.