### PR TITLE
add url and relatedTag to Associations and make Event and UserProfile only include a header of Association(s)

### DIFF
--- a/app/src/androidTest/java/com/github/swent/echo/compose/event/CreateEventScreenTest.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/compose/event/CreateEventScreenTest.kt
@@ -9,7 +9,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.github.swent.echo.MainActivity
 import com.github.swent.echo.authentication.AuthenticationService
 import com.github.swent.echo.connectivity.NetworkService
-import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.Event
 import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
@@ -46,7 +46,7 @@ class CreateEventScreenTest {
         Event(
             eventId = "testid",
             creator = EventCreator("testid", "testname"),
-            organizer = Association("testid", "testname", "testdesc"),
+            organizer = AssociationHeader("testid", "testname"),
             title = "test title",
             description = "test description",
             location = Location("test location", 10.0, 10.0),

--- a/app/src/androidTest/java/com/github/swent/echo/compose/event/EditEventScreenTest.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/compose/event/EditEventScreenTest.kt
@@ -10,7 +10,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.github.swent.echo.MainActivity
 import com.github.swent.echo.authentication.AuthenticationService
 import com.github.swent.echo.connectivity.NetworkService
-import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.Event
 import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
@@ -45,7 +45,7 @@ class EditEventScreenTest {
         Event(
             eventId = "testid",
             creator = EventCreator("testid", "testname"),
-            organizer = Association("testid", "testname", "testdesc"),
+            organizer = AssociationHeader("testid", "testname"),
             title = "test title",
             description = "test description",
             location = Location("test location", 10.0, 10.0),

--- a/app/src/androidTest/java/com/github/swent/echo/data/repository/datasources/SupabaseDataSourceTest.kt
+++ b/app/src/androidTest/java/com/github/swent/echo/data/repository/datasources/SupabaseDataSourceTest.kt
@@ -3,6 +3,7 @@ package com.github.swent.echo.data.repository.datasources
 import com.github.swent.echo.authentication.AuthenticationService
 import com.github.swent.echo.authentication.AuthenticationServiceImpl
 import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.Event
 import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
@@ -35,19 +36,21 @@ class SupabaseDataSourceTest {
 
     lateinit var source: SupabaseDataSource
 
+    private val tag = Tag("daba142a-a276-4b7e-824d-43ca088633ff", "Dummy Tag")
     private val association =
         Association(
             "b0122e3e-82ed-4409-83f9-dbfb9761db20",
             "Dummy Assoc",
-            "DO NOT DELETE/MODIFY: tests in repository.datasources.SupabaseTest will fail"
+            "DO NOT DELETE/MODIFY: tests in repository.datasources.SupabaseTest will fail",
+            "https://dummy-url.ch",
+            setOf(tag)
         )
-    private val tag = Tag("daba142a-a276-4b7e-824d-43ca088633ff", "Dummy Tag")
     private val rootTagId = "1d253a7e-eb8c-4546-bc98-1d3adadcffe8"
     private val event =
         Event(
             "3bcf6f25-81d4-4a14-9caa-c05feb593da0",
             EventCreator("4792cb7e-894e-4dad-bf7c-7f0660d0b648", "SubapaseDataSourceTest User"),
-            association,
+            AssociationHeader.fromAssociation(association),
             "Dummy Event",
             "blabla description",
             Location("testLocation", 0.0, 0.0),
@@ -65,8 +68,8 @@ class SupabaseDataSourceTest {
             null,
             null,
             setOf(tag),
-            setOf(association),
-            setOf(association)
+            setOf(AssociationHeader.fromAssociation(association)!!),
+            setOf(AssociationHeader.fromAssociation(association)!!)
         )
 
     @Before
@@ -87,6 +90,14 @@ class SupabaseDataSourceTest {
             source.getAssociation("b0122e3e-82ed-4409-83f9-dbfb9761db20")
         }
         assertEquals(association, associationFetched)
+    }
+
+    @Test
+    fun getAssociationsTest() {
+        val associationsFetched = runBlocking {
+            source.getAssociations(listOf("b0122e3e-82ed-4409-83f9-dbfb9761db20"))
+        }
+        assertEquals(listOf(association), associationsFetched)
     }
 
     @Test

--- a/app/src/main/java/com/github/swent/echo/data/SampleEvents.kt
+++ b/app/src/main/java/com/github/swent/echo/data/SampleEvents.kt
@@ -2,6 +2,7 @@ package com.github.swent.echo.data
 
 import com.github.swent.echo.compose.map.MAP_CENTER
 import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.Event
 import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
@@ -28,7 +29,7 @@ val SAMPLE_EVENTS: List<Event> =
         Event(
             eventId = "a",
             creator = EventCreator("a", ""),
-            organizer = Association("a", "a", ""),
+            organizer = AssociationHeader("a", "a"),
             title = "Bowling Event",
             description = "",
             location = Location("Location 1", MAP_CENTER.toLatLng()),
@@ -42,7 +43,7 @@ val SAMPLE_EVENTS: List<Event> =
         Event(
             eventId = "b",
             creator = EventCreator("a", ""),
-            organizer = Association("a", "a", ""),
+            organizer = AssociationHeader("a", "a"),
             title = "Swimming Event",
             description = "",
             location = Location("Location 2", MAP_CENTER.toLatLng().toDestPt(1000.0, 0.0)),
@@ -56,7 +57,7 @@ val SAMPLE_EVENTS: List<Event> =
         Event(
             eventId = "c",
             creator = EventCreator("b", "Chad"),
-            organizer = Association("B", "EPFL Mewing Group", ""),
+            organizer = AssociationHeader("B", "EPFL Mewing Group"),
             title = "Badminton Tournament",
             description = "Only the greatest humans shall participate. Win... or die.",
             location =
@@ -91,5 +92,17 @@ val SAMPLE_EVENTS: List<Event> =
             participantCount = 3,
             maxParticipants = 5,
             imageId = 0
+        )
+    )
+
+val SAMPLE_ASSOCIATIONS: List<Association> =
+    listOf(
+        Association("a", "a", "", "https://example.org", setOf(Tag("1", "Sport"))),
+        Association(
+            "B",
+            "EPFL Mewing Group",
+            "",
+            "https://example.com",
+            setOf(Tag("62", "Badminton"), Tag("1", "Sport"))
         )
     )

--- a/app/src/main/java/com/github/swent/echo/data/model/Association.kt
+++ b/app/src/main/java/com/github/swent/echo/data/model/Association.kt
@@ -1,15 +1,13 @@
 package com.github.swent.echo.data.model
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-@Serializable
 data class Association(
-    @SerialName("association_id") val associationId: String,
+    val associationId: String,
     val name: String,
-    val description: String
+    val description: String,
+    val url: String?,
+    val relatedTags: Set<Tag>
 ) {
     companion object {
-        val EMPTY = Association("", "", "")
+        val EMPTY = Association("", "", "", "", setOf())
     }
 }

--- a/app/src/main/java/com/github/swent/echo/data/model/AssociationHeader.kt
+++ b/app/src/main/java/com/github/swent/echo/data/model/AssociationHeader.kt
@@ -1,0 +1,24 @@
+package com.github.swent.echo.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AssociationHeader(
+    @SerialName("association_id") val associationId: String,
+    val name: String,
+) {
+    companion object {
+        val EMPTY = AssociationHeader("", "")
+
+        fun fromAssociation(association: Association?): AssociationHeader? {
+            return if (association != null)
+                AssociationHeader(association.associationId, association.name)
+            else null
+        }
+    }
+}
+
+fun List<Association>.toAssociationHeader(): List<AssociationHeader> {
+    return map { AssociationHeader.fromAssociation(it)!! }
+}

--- a/app/src/main/java/com/github/swent/echo/data/model/Event.kt
+++ b/app/src/main/java/com/github/swent/echo/data/model/Event.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Contextual
 data class Event(
     val eventId: String,
     val creator: EventCreator,
-    val organizer: Association?,
+    val organizer: AssociationHeader?,
     val title: String,
     val description: String,
     val location: Location,

--- a/app/src/main/java/com/github/swent/echo/data/model/UserProfile.kt
+++ b/app/src/main/java/com/github/swent/echo/data/model/UserProfile.kt
@@ -6,8 +6,8 @@ data class UserProfile(
     val semester: Semester?,
     val section: Section?,
     val tags: Set<Tag>,
-    val committeeMember: Set<Association>,
-    val associationsSubscriptions: Set<Association>,
+    val committeeMember: Set<AssociationHeader>,
+    val associationsSubscriptions: Set<AssociationHeader>,
 ) {
     fun toEventCreator(): EventCreator = EventCreator(userId, name)
 

--- a/app/src/main/java/com/github/swent/echo/data/repository/Repository.kt
+++ b/app/src/main/java/com/github/swent/echo/data/repository/Repository.kt
@@ -21,6 +21,8 @@ interface Repository {
      */
     suspend fun getAssociation(associationId: String): Association?
 
+    suspend fun getAssociations(associationIds: List<String>): List<Association>
+
     suspend fun getAllAssociations(): List<Association>
 
     /**

--- a/app/src/main/java/com/github/swent/echo/data/repository/SimpleRepository.kt
+++ b/app/src/main/java/com/github/swent/echo/data/repository/SimpleRepository.kt
@@ -3,6 +3,7 @@ package com.github.swent.echo.data.repository
 import com.github.swent.echo.authentication.AuthenticationService
 import com.github.swent.echo.compose.event.SECTION_ROOT_TAG_ID
 import com.github.swent.echo.compose.event.SEMESTER_ROOT_TAG_ID
+import com.github.swent.echo.data.SAMPLE_ASSOCIATIONS
 import com.github.swent.echo.data.SAMPLE_EVENTS
 import com.github.swent.echo.data.model.Association
 import com.github.swent.echo.data.model.Event
@@ -46,9 +47,6 @@ class SimpleRepository(authenticationService: AuthenticationService) : Repositor
         SAMPLE_EVENTS.forEach { event ->
             events.add(event)
             tags.addAll(event.tags)
-            if (event.organizer != null) {
-                associations.add(event.organizer)
-            }
             userProfiles.add(
                 UserProfile(
                     event.creator.userId,
@@ -61,6 +59,7 @@ class SimpleRepository(authenticationService: AuthenticationService) : Repositor
                 )
             )
         }
+        SAMPLE_ASSOCIATIONS.forEach { association -> associations.add(association) }
 
         // Add a user profile for the current user
         val userId = authenticationService.getCurrentUserID()
@@ -81,6 +80,10 @@ class SimpleRepository(authenticationService: AuthenticationService) : Repositor
 
     override suspend fun getAssociation(associationId: String): Association {
         return associations.find { it.associationId == associationId }!!
+    }
+
+    override suspend fun getAssociations(associationIds: List<String>): List<Association> {
+        return associations.filter { associationIds.contains(it.associationId) }
     }
 
     override suspend fun getAllAssociations(): List<Association> {

--- a/app/src/main/java/com/github/swent/echo/data/repository/datasources/LocalDataSource.kt
+++ b/app/src/main/java/com/github/swent/echo/data/repository/datasources/LocalDataSource.kt
@@ -22,7 +22,17 @@ interface LocalDataSource {
 
     suspend fun setAssociation(association: Association)
 
+    suspend fun getAssociations(
+        associationIds: List<String>,
+        syncedSecondsAgo: Long
+    ): List<Association>
+
     suspend fun getAllAssociations(syncedSecondsAgo: Long): List<Association>
+
+    suspend fun getAssociationIds(
+        associationIds: List<String>,
+        syncedSecondsAgo: Long
+    ): List<String>
 
     suspend fun getAllAssociationIds(secondsAgo: Long): List<String>
 

--- a/app/src/main/java/com/github/swent/echo/data/room/AppDatabase.kt
+++ b/app/src/main/java/com/github/swent/echo/data/room/AppDatabase.kt
@@ -8,6 +8,7 @@ import com.github.swent.echo.data.room.dao.EventRoomDao
 import com.github.swent.echo.data.room.dao.TagRoomDao
 import com.github.swent.echo.data.room.dao.UserProfileRoomDao
 import com.github.swent.echo.data.room.entity.AssociationRoom
+import com.github.swent.echo.data.room.entity.AssociationTagCrossRef
 import com.github.swent.echo.data.room.entity.EventRoom
 import com.github.swent.echo.data.room.entity.EventTagCrossRef
 import com.github.swent.echo.data.room.entity.JoinedEventRoom
@@ -21,6 +22,7 @@ import com.github.swent.echo.data.room.entity.UserProfileTagCrossRef
     entities =
         [
             AssociationRoom::class,
+            AssociationTagCrossRef::class,
             EventRoom::class,
             EventTagCrossRef::class,
             JoinedEventRoom::class,

--- a/app/src/main/java/com/github/swent/echo/data/room/RoomLocalDataSource.kt
+++ b/app/src/main/java/com/github/swent/echo/data/room/RoomLocalDataSource.kt
@@ -87,7 +87,9 @@ class RoomLocalDataSource @Inject constructor(db: AppDatabase) : LocalDataSource
                 }
             }
 
-        eventDao.deleteAllEventTagCrossRefsForEvents(associations.map { it.associationId })
+        associationDao.deleteAllAssociationTagCrossRefsForAssociations(
+            associations.map { it.associationId }
+        )
         tagDao.insertAll(tags.toTagRoomList())
         associationDao.insertAll(associations.map { AssociationRoom(it) })
         associationDao.insertAssociationTagCrossRefs(crossRefs)
@@ -125,7 +127,6 @@ class RoomLocalDataSource @Inject constructor(db: AppDatabase) : LocalDataSource
     }
 
     override suspend fun setEvents(events: List<Event>) {
-        val associations = events.mapNotNull { it.organizer }
         val tags = events.flatMap { it.tags }.toSet()
         val crossRefs =
             events.flatMap { event -> event.tags.map { EventTagCrossRef(event.eventId, it.tagId) } }

--- a/app/src/main/java/com/github/swent/echo/data/room/dao/AssociationRoomDao.kt
+++ b/app/src/main/java/com/github/swent/echo/data/room/dao/AssociationRoomDao.kt
@@ -2,25 +2,50 @@ package com.github.swent.echo.data.room.dao
 
 import androidx.room.Dao
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Upsert
 import com.github.swent.echo.data.room.entity.AssociationRoom
+import com.github.swent.echo.data.room.entity.AssociationTagCrossRef
+import com.github.swent.echo.data.room.entity.AssociationWithTags
 
 @Dao
 interface AssociationRoomDao {
     @Upsert suspend fun insert(association: AssociationRoom)
 
+    @Upsert
+    suspend fun insertAssociationTagCrossRefs(associationTagCrossRefs: List<AssociationTagCrossRef>)
+
+    @Query("DELETE FROM AssociationTagCrossRef WHERE associationId = :associationId")
+    suspend fun deleteAllAssociationTagCrossRefsForAssociation(associationId: String)
+
+    @Query("DELETE FROM AssociationTagCrossRef WHERE associationId IN (:associationIds)")
+    suspend fun deleteAllAssociationTagCrossRefsForAssociations(associationIds: List<String>)
+
     @Upsert suspend fun insertAll(associations: List<AssociationRoom>)
 
+    @Transaction
     @Query(
         "SELECT * FROM AssociationRoom WHERE associationId = :associationId AND timestamp >= :after"
     )
-    suspend fun get(associationId: String, after: Long): AssociationRoom?
+    suspend fun get(associationId: String, after: Long): AssociationWithTags?
 
+    @Transaction
+    @Query(
+        "SELECT * FROM AssociationRoom WHERE associationId IN (:associationIds) AND timestamp >= :after"
+    )
+    suspend fun get(associationIds: List<String>, after: Long): List<AssociationWithTags>
+
+    @Transaction
     @Query("SELECT * FROM AssociationRoom WHERE timestamp >= :after")
-    suspend fun getAll(after: Long): List<AssociationRoom>
+    suspend fun getAll(after: Long): List<AssociationWithTags>
 
     @Query("SELECT associationId FROM AssociationRoom WHERE timestamp >= :after")
     suspend fun getAllIds(after: Long): List<String>
+
+    @Query(
+        "SELECT associationId FROM AssociationRoom WHERE associationId IN (:associationIds) AND timestamp >= :after"
+    )
+    suspend fun getIdsFrom(associationIds: List<String>, after: Long): List<String>
 
     @Query("DELETE FROM AssociationRoom WHERE associationId NOT IN (:ids)")
     suspend fun deleteNotIn(ids: List<String>)

--- a/app/src/main/java/com/github/swent/echo/data/room/dao/EventRoomDao.kt
+++ b/app/src/main/java/com/github/swent/echo/data/room/dao/EventRoomDao.kt
@@ -7,7 +7,7 @@ import androidx.room.Transaction
 import androidx.room.Upsert
 import com.github.swent.echo.data.room.entity.EventRoom
 import com.github.swent.echo.data.room.entity.EventTagCrossRef
-import com.github.swent.echo.data.room.entity.EventWithOrganizerAndTags
+import com.github.swent.echo.data.room.entity.EventWithTags
 import com.github.swent.echo.data.room.entity.JoinedEventRoom
 
 @Dao
@@ -26,13 +26,13 @@ interface EventRoomDao {
 
     @Transaction
     @Query("SELECT * FROM EventRoom WHERE eventId = :eventId AND timestamp >= :after")
-    suspend fun get(eventId: String, after: Long): EventWithOrganizerAndTags?
+    suspend fun get(eventId: String, after: Long): EventWithTags?
 
     @Query("DELETE FROM EventRoom WHERE eventId = :eventId") suspend fun delete(eventId: String)
 
     @Transaction
     @Query("SELECT * FROM EventRoom WHERE timestamp >= :after")
-    suspend fun getAll(after: Long): List<EventWithOrganizerAndTags>
+    suspend fun getAll(after: Long): List<EventWithTags>
 
     @Query("SELECT eventId FROM EventRoom WHERE timestamp >= :after")
     suspend fun getAllIds(after: Long): List<String>
@@ -56,5 +56,5 @@ interface EventRoomDao {
 
     @Transaction
     @Query("SELECT * FROM EventRoom WHERE eventId IN (:eventIds)")
-    suspend fun getEventsByIds(eventIds: List<String>): List<EventWithOrganizerAndTags>
+    suspend fun getEventsByIds(eventIds: List<String>): List<EventWithTags>
 }

--- a/app/src/main/java/com/github/swent/echo/data/room/entity/AssociationHeaderRoom.kt
+++ b/app/src/main/java/com/github/swent/echo/data/room/entity/AssociationHeaderRoom.kt
@@ -1,0 +1,25 @@
+package com.github.swent.echo.data.room.entity
+
+import androidx.room.ColumnInfo
+import com.github.swent.echo.data.model.AssociationHeader
+
+data class AssociationHeaderRoom(
+    val associationId: String,
+    @ColumnInfo(name = "organizer_name") val name: String,
+) {
+    fun toAssociationHeader(): AssociationHeader = AssociationHeader(associationId, name)
+
+    companion object {
+        fun fromAssociationHeader(associationHeader: AssociationHeader?): AssociationHeaderRoom? {
+            return if (associationHeader != null) {
+                AssociationHeaderRoom(associationHeader.associationId, associationHeader.name)
+            } else {
+                null
+            }
+        }
+
+        fun fromAssociationRoom(associationRoom: AssociationRoom): AssociationHeaderRoom {
+            return AssociationHeaderRoom(associationRoom.associationId, associationRoom.name)
+        }
+    }
+}

--- a/app/src/main/java/com/github/swent/echo/data/room/entity/AssociationRoom.kt
+++ b/app/src/main/java/com/github/swent/echo/data/room/entity/AssociationRoom.kt
@@ -1,8 +1,15 @@
 package com.github.swent.echo.data.room.entity
 
+import androidx.room.Embedded
 import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.ForeignKey.Companion.CASCADE
+import androidx.room.Index
+import androidx.room.Junction
 import androidx.room.PrimaryKey
+import androidx.room.Relation
 import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import java.time.ZonedDateTime
 
 @Entity
@@ -10,20 +17,59 @@ data class AssociationRoom(
     @PrimaryKey val associationId: String,
     val name: String,
     val description: String,
+    val url: String?,
     /** The time of the last update in seconds */
     val timestamp: Long = ZonedDateTime.now().toEpochSecond(),
 ) {
     constructor(
         association: Association
-    ) : this(
-        association.associationId,
-        association.name,
-        association.description,
-    )
-
-    fun toAssociation(): Association = Association(associationId, name, description)
+    ) : this(association.associationId, association.name, association.description, association.url)
 }
 
-fun List<AssociationRoom>.toAssociationSet(): Set<Association> = map { it.toAssociation() }.toSet()
+@Entity(
+    primaryKeys = ["associationId", "tagId"],
+    indices = [Index("tagId")],
+    foreignKeys =
+        [
+            ForeignKey(
+                entity = AssociationRoom::class,
+                parentColumns = ["associationId"],
+                childColumns = ["associationId"],
+                onDelete = CASCADE,
+            ),
+            ForeignKey(
+                entity = TagRoom::class,
+                parentColumns = ["tagId"],
+                childColumns = ["tagId"],
+                onDelete = CASCADE,
+            ),
+        ],
+)
+data class AssociationTagCrossRef(
+    val associationId: String,
+    val tagId: String,
+)
 
-fun Set<Association>.toAssociationRoomList(): List<AssociationRoom> = map { AssociationRoom(it) }
+data class AssociationWithTags(
+    @Embedded val association: AssociationRoom,
+    @Relation(
+        parentColumn = "associationId",
+        entityColumn = "tagId",
+        associateBy = Junction(AssociationTagCrossRef::class),
+    )
+    val tags: List<TagRoom>
+) {
+    fun toAssociation(): Association =
+        Association(
+            association.associationId,
+            association.name,
+            association.description,
+            association.url,
+            tags.toTagSet(),
+        )
+}
+
+fun List<AssociationWithTags>.toAssociations(): List<Association> = map { it.toAssociation() }
+
+fun List<AssociationRoom>.toAssociationHeaderSet(): Set<AssociationHeader> =
+    map { AssociationHeaderRoom.fromAssociationRoom(it).toAssociationHeader() }.toSet()

--- a/app/src/main/java/com/github/swent/echo/data/room/entity/EventRoom.kt
+++ b/app/src/main/java/com/github/swent/echo/data/room/entity/EventRoom.kt
@@ -15,7 +15,7 @@ import java.time.ZonedDateTime
 data class EventRoom(
     @PrimaryKey val eventId: String,
     @Embedded val creator: EventCreatorRoom,
-    val organizerId: String?,
+    @Embedded val organizer: AssociationHeaderRoom?,
     val title: String,
     val description: String,
     @Embedded val location: LocationRoom,
@@ -32,7 +32,7 @@ data class EventRoom(
     ) : this(
         event.eventId,
         EventCreatorRoom(event.creator),
-        event.organizer?.associationId,
+        AssociationHeaderRoom.fromAssociationHeader(event.organizer),
         event.title,
         event.description,
         LocationRoom(event.location),
@@ -68,13 +68,8 @@ data class EventTagCrossRef(
     val tagId: String,
 )
 
-data class EventWithOrganizerAndTags(
+data class EventWithTags(
     @Embedded val event: EventRoom,
-    @Relation(
-        parentColumn = "organizerId",
-        entityColumn = "associationId",
-    )
-    val organizer: AssociationRoom?,
     @Relation(
         parentColumn = "eventId",
         entityColumn = "tagId",
@@ -87,7 +82,7 @@ data class EventWithOrganizerAndTags(
         Event(
             event.eventId,
             event.creator.toEventCreator(),
-            organizer?.toAssociation(),
+            event.organizer?.toAssociationHeader(),
             event.title,
             event.description,
             event.location.toLocation(),

--- a/app/src/main/java/com/github/swent/echo/data/room/entity/UserProfileRoom.kt
+++ b/app/src/main/java/com/github/swent/echo/data/room/entity/UserProfileRoom.kt
@@ -131,7 +131,7 @@ data class UserProfileWithTagsCommitteeMemberAndAssociationSubscription(
             userProfile.semester?.toSemesterEPFL(),
             userProfile.section?.toSectionEPFL(),
             tags.toTagSet(),
-            committeeMember.toAssociationSet(),
-            associationsSubscriptions.toAssociationSet(),
+            committeeMember.toAssociationHeaderSet(),
+            associationsSubscriptions.toAssociationHeaderSet(),
         )
 }

--- a/app/src/main/java/com/github/swent/echo/data/supabase/entities/AssociationHelper.kt
+++ b/app/src/main/java/com/github/swent/echo/data/supabase/entities/AssociationHelper.kt
@@ -1,9 +1,9 @@
 package com.github.swent.echo.data.supabase.entities
 
-import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 // This annotated helper class is needed for the serialization of the double join queries to work
 @Serializable
-data class AssociationHelper(@SerialName("associations") val association: Association)
+data class AssociationHelper(@SerialName("associations") val association: AssociationHeader)

--- a/app/src/main/java/com/github/swent/echo/data/supabase/entities/AssociationSupabase.kt
+++ b/app/src/main/java/com/github/swent/echo/data/supabase/entities/AssociationSupabase.kt
@@ -1,0 +1,36 @@
+package com.github.swent.echo.data.supabase.entities
+
+import com.github.swent.echo.data.model.Association
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AssociationSupabase(
+    @SerialName("association_id") val associationId: String,
+    val name: String,
+    val description: String,
+    @SerialName("association_url") val url: String?,
+    @SerialName("association_tags") val relatedTags: List<TagHelper>
+) {
+    constructor(
+        association: Association
+    ) : this(
+        association.associationId,
+        association.name,
+        association.description,
+        association.url,
+        association.relatedTags.map { tag -> TagHelper(tag) },
+    )
+
+    fun toAssociation(): Association {
+        return Association(
+            associationId,
+            name,
+            description,
+            url,
+            relatedTags.map { tagHelper -> tagHelper.tag }.toHashSet(),
+        )
+    }
+}
+
+fun List<AssociationSupabase>.toAssociations() = map { it.toAssociation() }

--- a/app/src/main/java/com/github/swent/echo/data/supabase/entities/AssociationTagSupabase.kt
+++ b/app/src/main/java/com/github/swent/echo/data/supabase/entities/AssociationTagSupabase.kt
@@ -1,0 +1,8 @@
+package com.github.swent.echo.data.supabase.entities
+
+import kotlinx.serialization.SerialName
+
+data class AssociationTagSupabase(
+    @SerialName("tag_id") val tagId: String,
+    @SerialName("association_id") val associationId: String
+)

--- a/app/src/main/java/com/github/swent/echo/data/supabase/entities/EventSupabase.kt
+++ b/app/src/main/java/com/github/swent/echo/data/supabase/entities/EventSupabase.kt
@@ -1,6 +1,6 @@
 package com.github.swent.echo.data.supabase.entities
 
-import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.Event
 import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
 data class EventSupabase(
     @SerialName("event_id") val eventId: String,
     @SerialName("user_profiles") val creator: EventCreator,
-    @SerialName("associations") val organizer: Association?,
+    @SerialName("associations") val organizer: AssociationHeader?,
     val title: String,
     val description: String,
     @SerialName("location_name") val locationName: String,

--- a/app/src/main/java/com/github/swent/echo/viewmodels/authentication/CreateProfileViewModel.kt
+++ b/app/src/main/java/com/github/swent/echo/viewmodels/authentication/CreateProfileViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.swent.echo.authentication.AuthenticationService
 import com.github.swent.echo.connectivity.NetworkService
-import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.Section
 import com.github.swent.echo.data.model.Semester
 import com.github.swent.echo.data.model.Tag
@@ -47,10 +47,10 @@ constructor(
     private val _tagList = MutableStateFlow<Set<Tag>>(emptySet())
     val tagList = _tagList.asStateFlow()
 
-    private val _committeeMember = MutableStateFlow<Set<Association>>(emptySet())
+    private val _committeeMember = MutableStateFlow<Set<AssociationHeader>>(emptySet())
     val committeeMember = _committeeMember.asStateFlow()
 
-    private val _associationSubscriptions = MutableStateFlow<Set<Association>>(emptySet())
+    private val _associationSubscriptions = MutableStateFlow<Set<AssociationHeader>>(emptySet())
     val associationSubscriptions = _associationSubscriptions.asStateFlow()
 
     private val _errorMessage = MutableStateFlow<String?>(null)

--- a/app/src/main/java/com/github/swent/echo/viewmodels/event/EventViewModel.kt
+++ b/app/src/main/java/com/github/swent/echo/viewmodels/event/EventViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.github.swent.echo.R
 import com.github.swent.echo.authentication.AuthenticationService
 import com.github.swent.echo.connectivity.NetworkService
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.Event
 import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
@@ -96,9 +97,11 @@ constructor(
                 setEvent(
                     event.value.copy(
                         organizer =
-                            repository.getAllAssociations().find { association ->
-                                association.name == organizerName
-                            }
+                            AssociationHeader.fromAssociation(
+                                repository.getAllAssociations().find { association ->
+                                    association.name == organizerName
+                                }
+                            )
                     )
                 )
             }

--- a/app/src/test/java/com/github/swent/echo/compose/association/AssociationDetailsTest.kt
+++ b/app/src/test/java/com/github/swent/echo/compose/association/AssociationDetailsTest.kt
@@ -7,9 +7,11 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.Event
 import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
+import com.github.swent.echo.data.model.Tag
 import java.time.ZonedDateTime
 import org.junit.Before
 import org.junit.Rule
@@ -21,13 +23,20 @@ class AssociationDetailsTest {
 
     @get:Rule val composeTestRule = createComposeRule()
 
-    private val testAssociation = Association("id 1", "name 1", "description 1")
+    private val testAssociation =
+        Association(
+            "id 1",
+            "name 1",
+            "description 1",
+            "url1",
+            setOf(Tag("tagId 1", "tag description"))
+        )
     private var isFollowed = mutableStateOf(false)
     private val testEvent =
         Event(
             "event 1",
             EventCreator.EMPTY,
-            testAssociation,
+            AssociationHeader.fromAssociation(testAssociation),
             "title 1",
             "",
             Location.EMPTY,

--- a/app/src/test/java/com/github/swent/echo/compose/association/AssociationListScreenTest.kt
+++ b/app/src/test/java/com/github/swent/echo/compose/association/AssociationListScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.Tag
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -18,9 +19,15 @@ class AssociationListScreenTest {
 
     private val testAssociations =
         listOf(
-            Association("id 1", "name 1", "description 1"),
-            Association("id 2", "name 2", "description 2"),
-            Association("id 3", "name 3", "description 3")
+            Association(
+                "id 1",
+                "name 1",
+                "description 1",
+                "url 1",
+                setOf(Tag("tag id 1", "tag description"))
+            ),
+            Association("id 2", "name 2", "description 2", "url 2", setOf(Tag.EMPTY)),
+            Association("id 3", "name 3", "description 3", "url 3", setOf())
         )
     private var onRowClicked = 0
     private var onAssociationClicked = 0

--- a/app/src/test/java/com/github/swent/echo/compose/association/AssociationScreenTest.kt
+++ b/app/src/test/java/com/github/swent/echo/compose/association/AssociationScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.swent.echo.MainActivity
 import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.Tag
 import com.github.swent.echo.ui.navigation.NavigationActions
 import com.github.swent.echo.viewmodels.association.AssociationViewModel
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -28,7 +29,8 @@ class AssociationScreenTest {
 
     private lateinit var navActions: NavigationActions
     private lateinit var associationViewModel: AssociationViewModel
-    private val testAssociation = Association("id 1", "name 1", "description 1")
+    private val testAssociation =
+        Association("id 1", "name 1", "description 1", "url 1", setOf(Tag.EMPTY))
 
     @Before
     fun setUp() {

--- a/app/src/test/java/com/github/swent/echo/compose/components/EventInfoSheetTest.kt
+++ b/app/src/test/java/com/github/swent/echo/compose/components/EventInfoSheetTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.swent.echo.MainActivity
-import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.Event
 import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
@@ -42,7 +42,7 @@ class EventInfoSheetTest {
                 Event(
                     eventId = "1",
                     creator = EventCreator("1", "Event Creator"),
-                    organizer = Association("1", "Event Organization", ""),
+                    organizer = AssociationHeader("1", "Event Organization"),
                     title = "Event Title",
                     description = "Event Description",
                     location = Location("", 0.0, 0.0),

--- a/app/src/test/java/com/github/swent/echo/data/model/AssociationHeaderTest.kt
+++ b/app/src/test/java/com/github/swent/echo/data/model/AssociationHeaderTest.kt
@@ -1,0 +1,21 @@
+package com.github.swent.echo.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AssociationHeaderTest {
+    @Test
+    fun toAssociationHeaderTest() {
+        val assocs =
+            listOf(
+                Association("id1", "name1", "description1", "url1", setOf(Tag("tagid", "tagname"))),
+                Association("id2", "name2", "description2", "url2", setOf(Tag.EMPTY)),
+            )
+        val assocheaders =
+            listOf(
+                AssociationHeader("id1", "name1"),
+                AssociationHeader("id2", "name2"),
+            )
+        assertEquals(assocheaders, assocs.toAssociationHeader())
+    }
+}

--- a/app/src/test/java/com/github/swent/echo/data/repository/SimpleRepositoryTest.kt
+++ b/app/src/test/java/com/github/swent/echo/data/repository/SimpleRepositoryTest.kt
@@ -50,6 +50,13 @@ class SimpleRepositoryTest {
     }
 
     @Test
+    fun `get Associations should return the associations with the given ids`() = runBlocking {
+        val associations = simpleRepository.getAllAssociations()
+        val result = simpleRepository.getAssociations(associations.map { it.associationId })
+        assertEquals(associations, result)
+    }
+
+    @Test
     fun `getEvent should return the event with the given id`() = runBlocking {
         val events = simpleRepository.getAllEvents()
         val expected = events.first()

--- a/app/src/test/java/com/github/swent/echo/data/room/AssociationHeaderRoom.kt
+++ b/app/src/test/java/com/github/swent/echo/data/room/AssociationHeaderRoom.kt
@@ -1,0 +1,25 @@
+package com.github.swent.echo.data.room
+
+import com.github.swent.echo.data.model.AssociationHeader
+import com.github.swent.echo.data.room.entity.AssociationHeaderRoom
+import com.github.swent.echo.data.room.entity.AssociationRoom
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class AssociationHeaderRoomTest {
+    @Test
+    fun toAndFromAssociationHeaderTest() {
+        val headerRoom = AssociationHeaderRoom("id", "name")
+        val header = AssociationHeader("id", "name")
+        assertEquals(header, headerRoom.toAssociationHeader())
+        assertEquals(headerRoom, AssociationHeaderRoom.fromAssociationHeader(header))
+        assertEquals(null, AssociationHeaderRoom.fromAssociationHeader(null))
+    }
+
+    @Test
+    fun fromAssociationRoomTest() {
+        val assocRoom = AssociationRoom("id", "name", "description", "url", 0)
+        val headerRoom = AssociationHeaderRoom("id", "name")
+        assertEquals(headerRoom, AssociationHeaderRoom.fromAssociationRoom(assocRoom))
+    }
+}

--- a/app/src/test/java/com/github/swent/echo/data/room/AssociationRoomTest.kt
+++ b/app/src/test/java/com/github/swent/echo/data/room/AssociationRoomTest.kt
@@ -1,0 +1,31 @@
+package com.github.swent.echo.data.room
+
+import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
+import com.github.swent.echo.data.model.Tag
+import com.github.swent.echo.data.room.entity.AssociationRoom
+import com.github.swent.echo.data.room.entity.AssociationWithTags
+import com.github.swent.echo.data.room.entity.TagRoom
+import com.github.swent.echo.data.room.entity.toAssociationHeaderSet
+import com.github.swent.echo.data.room.entity.toAssociations
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AssociationRoomTest {
+    @Test
+    fun associationConversionTest() {
+        val assoc =
+            listOf(
+                Association("id", "name", "desc", "url", setOf(Tag("tagid", "tagname", "parentid")))
+            )
+        val assocRoom = assoc.map { AssociationRoom(it) }
+        val assocWithTags =
+            assocRoom.map {
+                AssociationWithTags(it, listOf(TagRoom("tagid", "parentid", "tagname")))
+            }
+        val assocHeaderSet = setOf(AssociationHeader("id", "name"))
+
+        assertEquals(assoc, assocWithTags.toAssociations())
+        assertEquals(assocHeaderSet, assocRoom.toAssociationHeaderSet())
+    }
+}

--- a/app/src/test/java/com/github/swent/echo/data/supabase/entities/AssociationSupabaseTest.kt
+++ b/app/src/test/java/com/github/swent/echo/data/supabase/entities/AssociationSupabaseTest.kt
@@ -1,0 +1,16 @@
+package com.github.swent.echo.data.supabase.entities
+
+import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.Tag
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AssociationSupabaseTest {
+    @Test
+    fun toAssociationTest() {
+        val assoc = Association("id", "name", "desc", "url", setOf(Tag.EMPTY))
+        val assocSupa = AssociationSupabase(assoc)
+        assertEquals(assoc, assocSupa.toAssociation())
+        assertEquals(listOf(assoc), listOf(assocSupa).toAssociations())
+    }
+}

--- a/app/src/test/java/com/github/swent/echo/data/supabase/entities/EventSupabaseSetterTest.kt
+++ b/app/src/test/java/com/github/swent/echo/data/supabase/entities/EventSupabaseSetterTest.kt
@@ -1,6 +1,6 @@
 package com.github.swent.echo.data.supabase.entities
 
-import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.Event
 import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
@@ -16,7 +16,7 @@ class EventSupabaseSetterTest {
         Event(
             "eventId",
             EventCreator("creatorId", "creatorName"),
-            Association("organizerId", "organizerName", "organizerDescription"),
+            AssociationHeader("organizerId", "organizerName"),
             "title",
             "description",
             Location("locationName", 0.2, 0.3),

--- a/app/src/test/java/com/github/swent/echo/data/supabase/entities/EventSupabaseTest.kt
+++ b/app/src/test/java/com/github/swent/echo/data/supabase/entities/EventSupabaseTest.kt
@@ -1,6 +1,6 @@
 package com.github.swent.echo.data.supabase.entities
 
-import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.Event
 import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
@@ -16,7 +16,7 @@ class EventSupabaseTest {
         Event(
             "eventId",
             EventCreator("creatorId", "creatorName"),
-            Association("organizerId", "organizerName", "organizerDescription"),
+            AssociationHeader("organizerId", "organizerName"),
             "title",
             "description",
             Location("locationName", 0.2, 0.3),

--- a/app/src/test/java/com/github/swent/echo/data/supabase/entities/UserProfileSupabaseSetterTest.kt
+++ b/app/src/test/java/com/github/swent/echo/data/supabase/entities/UserProfileSupabaseSetterTest.kt
@@ -1,6 +1,6 @@
 package com.github.swent.echo.data.supabase.entities
 
-import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.SectionEPFL
 import com.github.swent.echo.data.model.SemesterEPFL
 import com.github.swent.echo.data.model.Tag
@@ -16,8 +16,8 @@ class UserProfileSupabaseSetterTest {
             SemesterEPFL.BA6,
             SectionEPFL.IN,
             setOf(Tag("tagId", "tagName")),
-            setOf(Association("associationId", "associationName", "associationDescription")),
-            setOf(Association("associationId", "associationName", "associationDescription")),
+            setOf(AssociationHeader("associationId", "associationName")),
+            setOf(AssociationHeader("associationId", "associationName")),
         )
 
     val userProfileSupabaseSetter =

--- a/app/src/test/java/com/github/swent/echo/data/supabase/entities/UserProfileSupabaseTest.kt
+++ b/app/src/test/java/com/github/swent/echo/data/supabase/entities/UserProfileSupabaseTest.kt
@@ -1,6 +1,6 @@
 package com.github.swent.echo.data.supabase.entities
 
-import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.SectionEPFL
 import com.github.swent.echo.data.model.SemesterEPFL
 import com.github.swent.echo.data.model.Tag
@@ -16,8 +16,8 @@ class UserProfileSupabaseTest {
             SemesterEPFL.BA6,
             SectionEPFL.IN,
             setOf(Tag("tagId", "tagName")),
-            setOf(Association("associationId", "associationName", "associationDescription")),
-            setOf(Association("associationId2", "associationName", "associationDescription")),
+            setOf(AssociationHeader("associationId", "associationName")),
+            setOf(AssociationHeader("associationId2", "associationName")),
         )
 
     val userProfileSupabase =

--- a/app/src/test/java/com/github/swent/echo/viewmodels/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/com/github/swent/echo/viewmodels/HomeScreenViewModelTest.kt
@@ -3,7 +3,7 @@ package com.github.swent.echo.viewmodels
 import com.github.swent.echo.compose.components.searchmenu.SortBy
 import com.github.swent.echo.compose.map.MAP_CENTER
 import com.github.swent.echo.connectivity.NetworkService
-import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.Event
 import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
@@ -39,7 +39,7 @@ class HomeScreenViewModelTest {
             Event(
                 eventId = "wow",
                 creator = EventCreator("a", ""),
-                organizer = Association("a", "a", ""),
+                organizer = AssociationHeader("a", "a"),
                 title = "Bowling Event",
                 description = "",
                 location = Location("Location 1", MAP_CENTER.toLatLng()),
@@ -157,7 +157,7 @@ class HomeScreenViewModelTest {
             Event(
                 eventId = "a",
                 creator = EventCreator("a", ""),
-                organizer = Association("a", "a", ""),
+                organizer = AssociationHeader("a", "a"),
                 title = "Bowling Event",
                 description = "",
                 location = Location("Location 1", MAP_CENTER.toLatLng()),
@@ -220,7 +220,7 @@ class HomeScreenViewModelTest {
                 Event(
                     eventId = "newEvent",
                     creator = EventCreator("a", ""),
-                    organizer = Association("a", "a", ""),
+                    organizer = AssociationHeader("a", "a"),
                     title = "New Event",
                     description = "",
                     location = Location("Location 2", MAP_CENTER.toLatLng()),

--- a/app/src/test/java/com/github/swent/echo/viewmodels/association/AssociationViewModelTest.kt
+++ b/app/src/test/java/com/github/swent/echo/viewmodels/association/AssociationViewModelTest.kt
@@ -3,11 +3,13 @@ package com.github.swent.echo.viewmodels.association
 import com.github.swent.echo.compose.map.MAP_CENTER
 import com.github.swent.echo.connectivity.NetworkService
 import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.Event
 import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
 import com.github.swent.echo.data.model.Tag
 import com.github.swent.echo.data.model.UserProfile
+import com.github.swent.echo.data.model.toAssociationHeader
 import com.github.swent.echo.data.repository.Repository
 import com.github.swent.echo.fakes.FakeAuthenticationService
 import io.mockk.coEvery
@@ -37,16 +39,22 @@ class AssociationViewModelTest {
                 associationId = "a",
                 name = "Association A",
                 description = "Description A",
+                url = "url A",
+                setOf(Tag("tagId", "tagDescription")),
             ),
             Association(
                 associationId = "b",
                 name = "Association B",
                 description = "Description B",
+                url = "url B",
+                setOf(Tag.EMPTY),
             ),
             Association(
                 associationId = "c",
                 name = "Association C",
                 description = "Description C",
+                url = "url C",
+                setOf(),
             )
         )
     private val userProfile =
@@ -56,15 +64,15 @@ class AssociationViewModelTest {
             semester = null,
             section = null,
             tags = setOf(),
-            committeeMember = associationList.subList(0, 1).toSet(),
-            associationsSubscriptions = associationList.subList(0, 2).toSet()
+            committeeMember = associationList.subList(0, 1).toAssociationHeader().toSet(),
+            associationsSubscriptions = associationList.subList(0, 2).toAssociationHeader().toSet()
         )
     private val eventList =
         listOf(
             Event(
                 eventId = "wow",
                 creator = EventCreator("a", ""),
-                organizer = associationList[0],
+                organizer = AssociationHeader.fromAssociation(associationList[0]),
                 title = "Bowling Event",
                 description = "",
                 location = Location("Location 1", MAP_CENTER.toLatLng()),
@@ -78,7 +86,7 @@ class AssociationViewModelTest {
             Event(
                 eventId = "test",
                 creator = EventCreator("a", ""),
-                organizer = associationList[1],
+                organizer = AssociationHeader.fromAssociation(associationList[1]),
                 title = "Test Event",
                 description = "",
                 location = Location("Location 2", MAP_CENTER.toLatLng()),
@@ -92,7 +100,7 @@ class AssociationViewModelTest {
             Event(
                 eventId = "wow2",
                 creator = EventCreator("a", ""),
-                organizer = associationList[2],
+                organizer = AssociationHeader.fromAssociation(associationList[2]),
                 title = "Bowling Event 2",
                 description = "",
                 location = Location("Location 3", MAP_CENTER.toLatLng()),
@@ -150,7 +158,7 @@ class AssociationViewModelTest {
         val association = associationList[0]
         val events = associationViewModel.associationEvents(association)
         assert(events.size == 1)
-        assert(events[0].organizer == association)
+        assert(events[0].organizer == AssociationHeader.fromAssociation(association))
     }
 
     @Test
@@ -171,7 +179,7 @@ class AssociationViewModelTest {
                 Event(
                     eventId = "newEvent",
                     creator = EventCreator("a", ""),
-                    organizer = associationList[0],
+                    organizer = AssociationHeader.fromAssociation(associationList[0]),
                     title = "New Event",
                     description = "",
                     location = Location("Location 2", MAP_CENTER.toLatLng()),

--- a/app/src/test/java/com/github/swent/echo/viewmodels/event/EventViewModelTest.kt
+++ b/app/src/test/java/com/github/swent/echo/viewmodels/event/EventViewModelTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.github.swent.echo.authentication.AuthenticationService
 import com.github.swent.echo.connectivity.NetworkService
 import com.github.swent.echo.data.model.Association
+import com.github.swent.echo.data.model.AssociationHeader
 import com.github.swent.echo.data.model.Event
 import com.github.swent.echo.data.model.EventCreator
 import com.github.swent.echo.data.model.Location
@@ -39,7 +40,7 @@ class EventViewModelTest {
         Event(
             eventId = "testid",
             creator = EventCreator("testid", "testname"),
-            organizer = Association("testid", "testname", "testdesc"),
+            organizer = AssociationHeader("testid", "testname"),
             title = "test title",
             description = "test description",
             location = Location("test location", 10.0, 10.0),
@@ -232,12 +233,16 @@ class EventViewModelTest {
 
     @Test
     fun setOrganizerNameAsAssociationSetTheCorrectValue() {
-        val testAssociation = Association("testAid", "testAname", "testDescription")
+        val testAssociation =
+            Association("testAid", "testAname", "testDescription", "testUrl", setOf())
         eventViewModel.setEvent(TEST_EVENT)
         coEvery { mockedRepository.getAllAssociations() } returns listOf(testAssociation)
         eventViewModel.setOrganizer(testAssociation.name)
         scheduler.runCurrent()
-        assertEquals(testAssociation, eventViewModel.event.value.organizer)
+        assertEquals(
+            AssociationHeader.fromAssociation(testAssociation),
+            eventViewModel.event.value.organizer
+        )
     }
 
     @Test


### PR DESCRIPTION
closes #264

This extends the Association dataclass to hold two additional attributes: `url` and `relatedTags`. While the url is a simple string field in the db, the relatedTags are stored as a relation between the Association and the Tag. 
Since Associations were embedded inside Events as well as UserProfile data classes, this would have meant fetching all the Tags related to the Associations whenever we want a UserProfile (or an Event). To be precise, we talk about multiple four-way nested joins across a total of 8 tables to fetch a UserProfile. In order to simplify this, together with @octogradiste we decided to not embed Associations in Events and UserProfiles anymore. Instead we just embed a simplified object, called `AssociationHeader`, only containing the id and the name of the Association, analogous to how we already do it for the `EventCreator` on Events.